### PR TITLE
Fix openat macosx

### DIFF
--- a/src/compat/fstatat.c
+++ b/src/compat/fstatat.c
@@ -1,16 +1,20 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include "dir_mutex.h"
 
 int fstatat(int dirfd, const char *pathname, struct stat *buf, int flags)
 {
 	int rc;
+	int cwd;
 
 	pthread_mutex_lock(&dir_mutex);
 
+	cwd = open(".", O_RDONLY);
 	if(fchdir(dirfd) < 0) {
+		close(cwd);
 		perror("fchdir");
 		goto err_unlock;
 	}
@@ -19,6 +23,8 @@ int fstatat(int dirfd, const char *pathname, struct stat *buf, int flags)
 	} else {
 		rc = stat(pathname, buf);
 	}
+	fchdir(cwd);
+	close(cwd);
 	pthread_mutex_unlock(&dir_mutex);
 	return rc;
 

--- a/src/compat/mkdirat.c
+++ b/src/compat/mkdirat.c
@@ -11,16 +11,21 @@
 int mkdirat(int dirfd, const char *pathname, mode_t mode)
 {
 	int rc;
+	int cwd;
 
 	if(mode) {/* for win32 */}
 
 	pthread_mutex_lock(&dir_mutex);
 
+	cwd = open(".", O_RDONLY);
 	if(fchdir(dirfd) < 0) {
+		close(cwd);
 		perror("fchdir");
 		goto err_unlock;
 	}
 	rc = mkdir(pathname, mode);
+	fchdir(cwd);
+	close(cwd);
 	pthread_mutex_unlock(&dir_mutex);
 	return rc;
 

--- a/src/compat/openat.c
+++ b/src/compat/openat.c
@@ -8,10 +8,13 @@ int openat(int dirfd, const char *pathname, int flags, ...)
 {
 	int fd;
 	mode_t mode = 0;
+	int cwd;
 
 	pthread_mutex_lock(&dir_mutex);
 
+	cwd = open(".", O_RDONLY);
 	if(fchdir(dirfd) < 0) {
+		close(cwd);
 		perror("fchdir");
 		goto err_unlock;
 	}
@@ -22,6 +25,8 @@ int openat(int dirfd, const char *pathname, int flags, ...)
 		va_end(ap);
 	}
 	fd = open(pathname, flags, mode);
+	fchdir(cwd);
+	close(cwd);
 	pthread_mutex_unlock(&dir_mutex);
 	return fd;
 

--- a/src/compat/readlinkat.c
+++ b/src/compat/readlinkat.c
@@ -6,14 +6,19 @@
 int readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz)
 {
 	int rc;
+	int cwd;
 
 	pthread_mutex_lock(&dir_mutex);
 
+	cwd = open(".", O_RDONLY);
 	if(fchdir(dirfd) < 0) {
+		close(cwd);
 		perror("fchdir");
 		goto err_unlock;
 	}
 	rc = readlink(pathname, buf, bufsiz);
+	fchdir(cwd);
+	close(cwd);
 	pthread_mutex_unlock(&dir_mutex);
 	return rc;
 

--- a/src/compat/unlinkat.c
+++ b/src/compat/unlinkat.c
@@ -6,6 +6,7 @@
 int unlinkat(int dirfd, const char *pathname, int flags)
 {
 	int rc;
+	int cwd;
 
 	if(flags != 0) {
 		fprintf(stderr, "tup compat unlinkat error: flags=%i not supported\n", flags);
@@ -14,11 +15,15 @@ int unlinkat(int dirfd, const char *pathname, int flags)
 
 	pthread_mutex_lock(&dir_mutex);
 
+	cwd = open(".", O_RDONLY);
 	if(fchdir(dirfd) < 0) {
+		close(cwd);
 		perror("fchdir");
 		goto err_unlock;
 	}
 	rc = unlink(pathname);
+	fchdir(cwd);
+	close(cwd);
 	pthread_mutex_unlock(&dir_mutex);
 	return rc;
 


### PR DESCRIPTION
CWD is shared among all threads so changing it in one thread may affect other threads.
This is actually what happend with macosx - main thread changes CWD and fuse thread sees
other CWD that causes a bug.
