### PR TITLE
Declare static shared varibale as volatile and atomic.

### DIFF
--- a/src/tup/server/fuse_server.c
+++ b/src/tup/server/fuse_server.c
@@ -36,7 +36,7 @@ static struct sigaction sigact = {
 	.sa_handler = sighandler,
 	.sa_flags = SA_RESTART,
 };
-static int sig_quit = 0;
+static volatile sig_atomic_t sig_quit = 0;
 
 static void *fuse_thread(void *arg)
 {


### PR DESCRIPTION
If a signal handler modifies shared variable such variable should be
declared as volatile. There also is a special atomic type that should
be used instead of int in signal handlers - sig_atomic_t.

See more info here http://www.cs.utah.edu/dept/old/texinfo/glibc-manual-0.02/library_21.html#SEC352
