### PR TITLE
Use GCC from MacPorts.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,6 +3,7 @@ os=`uname -s`
 plat_cflags="`pkg-config fuse --cflags`"
 plat_ldflags="`pkg-config fuse --libs`"
 plat_files=""
+CC=gcc
 case "$os" in
 	Linux)
 	plat_files="$plat_files ../src/compat/dummy.c"
@@ -22,6 +23,7 @@ case "$os" in
 	plat_files="$plat_files ../src/compat/readlinkat.c"
 	plat_files="$plat_files ../src/compat/unlinkat.c"
 	plat_cflags="$plat_cflags -DAT_SYMLINK_NOFOLLOW=0x100"
+	CC=gcc-mp-4.6
 	;;
 esac
 
@@ -32,15 +34,15 @@ echo "  cd build"
 cd build
 for i in ../src/linux/*.c ../src/tup/*.c ../src/tup/tup/main.c ../src/tup/access_event/send_event.c ../src/tup/monitor/null.c ../src/tup/colors/colors.c ../src/tup/flock/fcntl.c ../src/tup/server/fuse*.c $plat_files; do
 	echo "  bootstrap CC (unoptimized) $i"
-	gcc -c $i -I../src $plat_cflags
+	$CC -c $i -I../src $plat_cflags
 done
 
 echo "  bootstrap CC (unoptimized) ../src/sqlite3/sqlite3.c"
-gcc -c ../src/sqlite3/sqlite3.c -DSQLITE_TEMP_STORE=2 -DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_LOAD_EXTENSION $plat_cflags
+$CC -c ../src/sqlite3/sqlite3.c -DSQLITE_TEMP_STORE=2 -DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_LOAD_EXTENSION $plat_cflags
 
 echo "  bootstrap LD tup"
 echo "const char *tup_version(void) {return \"bootstrap\";}" | gcc -x c -c - -o tup_version.o
-gcc *.o -o tup -lpthread $plat_ldflags
+$CC *.o -o tup -lpthread $plat_ldflags
 
 cd ..
 # We may be bootstrapping over an already-inited area.

--- a/macosx.tup
+++ b/macosx.tup
@@ -1,2 +1,7 @@
+# GCC on MacOSX is horribly outdated. Tup needs 4.6 version from MacPorts.
+# Take into account that if you have 64bits MacOSX you need to install gcc with universal binaries support:
+# port upgrade --enforce-variants gcc46 +universal
+CC = gcc-mp-4.6
+
 CFLAGS += -DAT_SYMLINK_NOFOLLOW=0x100
 CFLAGS += -DAT_FDCWD=-100


### PR DESCRIPTION
GCC from XCode is horribly outdated because of the crappy Apple's licensing
rules. If Tup wants to use newer GCC/C features (such as __thread) it needs
at least GCC 4.5. Clang (which is eventually will become a standard C compiler
in MacOSX) does not support __thread yet. Support of thread-local storage
(together with C++0x thread_local and C1X _Thread_local) is going to be added
to it some day, but it is not there yet.

So the only option is to use the latest GCC from macports. And use 'lipo' tool
directly if you need universal binaries.

Note: if you have 64bit MacOSX version you need to install macport's GCC
with '+universal' variant.
