### PR TITLE
Reimplement *at() functions by restoring path to dirfd

### DIFF
--- a/src/compat/Tupfile
+++ b/src/compat/Tupfile
@@ -6,7 +6,7 @@ srcs += dummy.c
 endif
 
 ifeq (@(TUP_PLATFORM),macosx)
-srcs += dir_mutex.c
+srcs += dummy.c
 srcs += fstatat.c
 srcs += mkdirat.c
 srcs += openat.c

--- a/src/compat/unlinkat.c
+++ b/src/compat/unlinkat.c
@@ -1,33 +1,21 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include "dir_mutex.h"
+#include <sys/param.h>
+#include <string.h>
 
 int unlinkat(int dirfd, const char *pathname, int flags)
 {
-	int rc;
-	int cwd;
+	char fullpath[MAXPATHLEN];
 
 	if(flags != 0) {
 		fprintf(stderr, "tup compat unlinkat error: flags=%i not supported\n", flags);
 		return -1;
 	}
 
-	pthread_mutex_lock(&dir_mutex);
+	fcntl(dirfd, F_GETPATH, fullpath);
+	strlcat(fullpath, "/", MAXPATHLEN);
+	strlcat(fullpath, pathname, MAXPATHLEN);
 
-	cwd = open(".", O_RDONLY);
-	if(fchdir(dirfd) < 0) {
-		perror("fchdir");
-		close(cwd);
-		goto err_unlock;
-	}
-	rc = unlink(pathname);
-	fchdir(cwd);
-	close(cwd);
-	pthread_mutex_unlock(&dir_mutex);
-	return rc;
-
-err_unlock:
-	pthread_mutex_unlock(&dir_mutex);
-	return -1;
+	return unlink(pathname);
 }


### PR DESCRIPTION
Current implementation that uses chdir(dirfd) is really ugly solution
as it changes the process working directory. This leads to race conditions.

The better way is to restore path from dirfd by using fcntl() and use it
to construct full path to the target file.
