### PR TITLE
Fix test

### DIFF
--- a/test/t4040-statfs.sh
+++ b/test/t4040-statfs.sh
@@ -5,7 +5,13 @@
 . ./tup.sh
 
 cat > ok.c << HERE
+#ifdef __linux__
 #include <sys/vfs.h>
+#elif __APPLE__
+#include <sys/mount.h>
+#else
+#error Please add support for this test in t4040-statfs.sh
+#endif
 int main(void)
 {
 	struct statfs buf;


### PR DESCRIPTION
It produces following error in MacOSX:

ok.c:1:21: error: sys/vfs.h: No such file or directory
ok.c: In function ‘main’:
ok.c:4: error: storage size of ‘buf’ isn’t known
