### PR TITLE
Make 'tup todo' output more consistent with 'tup upd'

### DIFF
--- a/src/tup/updater.c
+++ b/src/tup/updater.c
@@ -189,6 +189,8 @@ int todo(int argc, char **argv)
 	for(x=0; x<argc; x++) {
 		if(strcmp(argv[x], "--no-scan") == 0) {
 			do_scan = 0;
+		} else if(strcmp(argv[x], "--verbose") == 0) {
+			tup_entry_set_verbose(1);
 		} else if(strcmp(argv[x], "--") == 0) {
 			break;
 		}
@@ -928,7 +930,6 @@ static void *todo_work(void *arg)
 
 		if(n->tent->type == g->count_flags) {
 			show_progress(n->tent, 0);
-			tup_db_print(stdout, n->tnode.tupid);
 		}
 
 		worker_ret(wt, 0);

--- a/tup.1
+++ b/tup.1
@@ -162,6 +162,9 @@ Prints out the next steps in the tup process that will execute when updating the
 .TP
 .B --no-scan
 Do not scan the project for changed files. This is for internal tup testing only, and should not be used during normal development.
+.TP
+.B --verbose
+Causes tup to display the full command string instead of just the pretty-printed string for commands that use the ^ TEXT^ prefix.
 .RE
 .TP
 .B varsed


### PR DESCRIPTION
Currently tup todo duplicates command name. It is better to show
the same info as for 'tup upd'.

Add --verbose flag to 'todo' to mach 'upd' behavior.
