### PR TITLE
Fix groff formatter warning

### DIFF
--- a/tup.1
+++ b/tup.1
@@ -104,7 +104,7 @@ Displays the current tup database configuration. These are internal values used 
 Displays all of the current tup options, as well as where they originated. The options are read in the following precedence order:
 .nf
 command-line overrides (eg: -j flag passed to 'tup upd')
-\.tup/options file
+\&.tup/options file
 ~/.tupoptions file
 /etc/tup/options file
 tup's compiled in defaults


### PR DESCRIPTION
Insert an empty break instead of esaping a special symbol. Escape causes
incorrect formatting and 'macro tup/options is not defined' warning.

You can see this warning by running 'man --warning ./tup.1 > /dev/null'
