### PR TITLE
Fix warnings on my ancient RHEL5 workstation

### DIFF
--- a/src/compat/utimensat.h
+++ b/src/compat/utimensat.h
@@ -1,0 +1,29 @@
+/* vim: set ts=8 sw=8 sts=8 noet tw=78:
+ *
+ * tup - A file-based build system
+ *
+ * Copyright (C) 2008-2011  Mike Shal <marfey@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef compat_utimensat_h
+#define compat_utimensat_h
+
+#include <time.h>
+
+int utimensat(int dirfd, const char *pathname,
+	      const struct timespec times[2], int flags);
+
+#endif

--- a/src/compat/utimensat_linux.c
+++ b/src/compat/utimensat_linux.c
@@ -19,6 +19,7 @@
  */
 
 #define _GNU_SOURCE
+#include "compat/utimensat.h"
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>

--- a/src/tup/config.c
+++ b/src/tup/config.c
@@ -18,6 +18,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#define _ATFILE_SOURCE
 #include "config.h"
 #include "compat.h"
 #include "colors.h"

--- a/src/tup/server/fuse_fs.c
+++ b/src/tup/server/fuse_fs.c
@@ -20,11 +20,13 @@
 
 #define _POSIX_C_SOURCE 200809L
 #define _ATFILE_SOURCE
+#define _GNU_SOURCE
 #ifdef linux
 /* For pread()/pwrite() */
 #define _XOPEN_SOURCE 500
 #endif
 
+#include "compat/utimensat.h"
 #include "tup_fuse_fs.h"
 #include "tup/config.h"
 #include "tup/debug.h"
@@ -35,6 +37,7 @@
 #include <string.h>
 #include <dirent.h>
 #include <errno.h>
+#include <sys/types.h>
 
 static struct thread_root troot = THREAD_ROOT_INITIALIZER;
 static int server_mode = 0;


### PR DESCRIPTION
This is a minor update to fix compiler warnings on an old RHEL5 workstation (glibc 2.6, gcc 4.1.2).

Cheers,
Mike
