### PR TITLE
test environment should ignore GREP_OPTIONS that may be set by the user

### DIFF
--- a/test/tup.sh
+++ b/test/tup.sh
@@ -44,6 +44,10 @@ CYGWIN*)
 ;;
 esac
 
+# override any user settings for grep
+GREP_OPTIONS=""
+export GREP_OPTIONS
+
 tmkdir()
 {
 	mkdir $1


### PR DESCRIPTION
I have mine set to ignore binary files, resulting in test failures when the vardict is checked for values.
