### PR TITLE
32bit compile as an option

### DIFF
--- a/Tupfile
+++ b/Tupfile
@@ -25,7 +25,7 @@ suid = ; chown root:root tup; chmod u+s tup
 endif
 
 LDFLAGS += `pkg-config fuse --libs`
-: src/tup/tup/main.o libtup.a |> ^ LINK tup^ version=`git describe`; echo "const char *tup_version(void) {return \"$version\";}" | $(CC) -x c -c - -o tup-version.o; $(CC) %f tup-version.o -o tup -lpthread $(LDFLAGS) $(suid) |> tup tup-version.o
+: src/tup/tup/main.o libtup.a |> ^ LINK tup^ version=`git describe`; echo "const char *tup_version(void) {return \"$version\";}" | $(CC) -x c -c - -o tup-version.o $(CFLAGS); $(CC) %f tup-version.o -o tup -lpthread $(LDFLAGS) $(suid) |> tup tup-version.o
 
 ifneq (@(TUP_MINGW),)
 : src/dllinject/*.omingw |> ^ MINGW32LINK %o^ @(TUP_MINGW)-gcc -shared %f -lws2_32 -lpsapi -lshlwapi -o %o |> tup-dllinject.dll

--- a/Tuprules.tup
+++ b/Tuprules.tup
@@ -28,6 +28,11 @@ CFLAGS += -Wswitch-enum
 CFLAGS += -fno-common
 CFLAGS += -I$(TUP_CWD)/src
 
+ifeq (@(TUP_32_BIT),y)
+CFLAGS += -m32
+LDFLAGS += -m32
+endif
+
 export PKG_CONFIG_PATH
 CFLAGS += `pkg-config fuse --cflags`
 


### PR DESCRIPTION
Note that the tests related to TUP_ARCH don't pass when enforcing 32bit on a 64bit machine... I think this is okay; maybe the tests need to be updated.
