### PR TITLE
Implemented stronger function hooking using "hot patching" method.

### DIFF
--- a/src/dllinject/hot_patch.c
+++ b/src/dllinject/hot_patch.c
@@ -1,0 +1,89 @@
+/* vim: set ts=8 sw=8 sts=8 noet tw=78:
+ *
+ * tup - A file-based build system
+ *
+ * Copyright (C) 2010-2012  Mike Shal <marfey@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "hot_patch.h"
+#include "trace.h"
+#include <windows.h>
+
+
+static int hot_patch_int( void *old_proc, void *new_proc, void **orig_proc )
+{
+	static const BYTE signature[] =
+	{
+		0x90, // nop
+	    0x90,
+		0x90,
+		0x90,
+		0x90,
+		// <- function start here
+		0x8b, 0xff // movl %edi,%edi
+	};
+
+	BYTE *begin = (BYTE*)old_proc - 5;
+
+	DWORD old_protect;
+    if( !VirtualProtect( (PVOID)begin, sizeof( signature ),
+                         PAGE_EXECUTE_WRITECOPY, &old_protect ) )
+    	return -1;
+
+    int ret = -1;
+    if( memcmp( (PVOID)begin, signature, sizeof( signature ) ) )
+    {
+    	DEBUG_HOOK( "%x %x %x %x %x %x %x\n",
+    			    begin[0], begin[1],begin[2],begin[3],begin[4],begin[5],begin[6] );
+    	goto exit;
+    }
+
+    *( begin + 0 ) = 0xe9; // long jump
+    *(DWORD*)( begin + 1 ) = (DWORD)new_proc - (DWORD)old_proc;
+    *(WORD*)( begin + 5 ) = 0xf9eb; // short jump back
+
+    if( orig_proc )
+    	*orig_proc = (BYTE*)old_proc + 2;
+
+    ret = 0;
+exit:;
+    VirtualProtect( begin, sizeof( signature ), old_protect, &old_protect );
+    return ret;
+}
+
+int hot_patch( patch_entry *begin, patch_entry *end )
+{
+	patch_entry *i;
+	for( i = begin; i != end; i++ )
+	{
+		HMODULE mod = GetModuleHandle( i->module );
+		if( !mod )
+			continue;
+
+		void *old_proc = GetProcAddress( mod, i->name );
+		if( !old_proc )
+			continue;
+
+		if( hot_patch_int( old_proc, i->new_proc, i->orig_proc ) != 0 )
+			DEBUG_HOOK( "not hot-patchable (%s)\n", i->name );
+	    else
+	    {
+	    	i->skip = 1;
+	    }
+	}
+
+	return 0;
+}
+

--- a/src/dllinject/hot_patch.h
+++ b/src/dllinject/hot_patch.h
@@ -1,0 +1,23 @@
+/* vim: set ts=8 sw=8 sts=8 noet tw=78:
+ *
+ * tup - A file-based build system
+ *
+ * Copyright (C) 2010-2012  Mike Shal <marfey@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+#include "patch.h"
+
+int hot_patch( patch_entry *begin, patch_entry *end );

--- a/src/dllinject/iat_patch.c
+++ b/src/dllinject/iat_patch.c
@@ -1,0 +1,117 @@
+/* vim: set ts=8 sw=8 sts=8 noet tw=78:
+ *
+ * tup - A file-based build system
+ *
+ * Copyright (C) 2010  James McKaskill
+ * Copyright (C) 2010-2012  Mike Shal <marfey@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "iat_patch.h"
+#include "trace.h"
+#include <windows.h>
+#include <psapi.h>
+
+
+static void do_hook( void* fphook, void** fporig, IMAGE_THUNK_DATA* cur )
+{
+	DWORD old_protect;
+	*fporig = (void*) cur->u1.Function;
+	if (!VirtualProtect(cur, sizeof(IMAGE_THUNK_DATA), PAGE_EXECUTE_READWRITE, &old_protect)) {
+		return;
+	}
+
+	cur->u1.Function = (DWORD)fphook;
+
+	if (!VirtualProtect(cur, sizeof(IMAGE_THUNK_DATA), old_protect, &old_protect)) {
+		return;
+	}
+}
+
+
+static void hook( HMODULE h, const char *module_name, IMAGE_THUNK_DATA* orig, IMAGE_THUNK_DATA* cur,
+		          const patch_entry *begin, const patch_entry *end )
+{
+	if (orig->u1.Ordinal & IMAGE_ORDINAL_FLAG)
+		return;
+
+	IMAGE_IMPORT_BY_NAME* name = (IMAGE_IMPORT_BY_NAME*) (orig->u1.AddressOfData + (char*) h);
+	const patch_entry *i;
+	for( i = begin; i != end; i++ )
+	{
+		if( i->skip )
+			continue;
+		if( stricmp( module_name, i->module ) )
+			continue;
+		if( strcmp( (const char*) name->Name, i->name ) )
+			continue;
+		do_hook( i->new_proc, i->orig_proc, cur );
+	}
+}
+
+
+static void foreach_module( HMODULE h, const patch_entry *begin, const patch_entry *end )
+{
+	IMAGE_DOS_HEADER* dos_header;
+	IMAGE_NT_HEADERS* nt_headers;
+	IMAGE_DATA_DIRECTORY* import_dir;
+	IMAGE_IMPORT_DESCRIPTOR* imports;
+
+	dos_header = (IMAGE_DOS_HEADER*) h;
+	nt_headers = (IMAGE_NT_HEADERS*) (dos_header->e_lfanew + (char*) h);
+
+	import_dir = &nt_headers->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT];
+	imports = (IMAGE_IMPORT_DESCRIPTOR*) (import_dir->VirtualAddress + (char*) h);
+	if (import_dir->VirtualAddress == 0)
+		return;
+
+	while (imports->Name != 0) {
+		char* dllname = (char*) h + imports->Name;
+		if (imports->FirstThunk && imports->OriginalFirstThunk) {
+			IMAGE_THUNK_DATA* cur = (IMAGE_THUNK_DATA*) (imports->FirstThunk + (char*) h);
+			IMAGE_THUNK_DATA* orig = (IMAGE_THUNK_DATA*) (imports->OriginalFirstThunk + (char*) h);
+
+			while (cur->u1.Function && orig->u1.Function) {
+				hook( h, dllname, orig, cur, begin, end );
+				cur++;
+				orig++;
+			}
+		}
+		imports++;
+	}
+}
+
+
+int iat_patch( patch_entry *begin, patch_entry *end )
+{
+	DWORD modnum;
+	HMODULE modules[256];
+	char filename[MAX_PATH];
+
+	if( !EnumProcessModules(GetCurrentProcess(), modules, sizeof(modules), &modnum) )
+		return -1;
+
+	modnum /= sizeof(HMODULE);
+
+	DWORD i;
+	for( i = 0; i < modnum; i++) {
+		if (!GetModuleFileNameA(modules[i], filename, sizeof(filename))) {
+			return -1;
+		}
+		foreach_module( modules[i], begin, end );
+	}
+
+	return 0;
+}
+

--- a/src/dllinject/iat_patch.h
+++ b/src/dllinject/iat_patch.h
@@ -1,0 +1,24 @@
+/* vim: set ts=8 sw=8 sts=8 noet tw=78:
+ *
+ * tup - A file-based build system
+ *
+ * Copyright (C) 2010  James McKaskill
+ * Copyright (C) 2010-2012  Mike Shal <marfey@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+#include "patch.h"
+
+int iat_patch( patch_entry *begin, patch_entry *end );

--- a/src/dllinject/patch.h
+++ b/src/dllinject/patch.h
@@ -1,0 +1,29 @@
+/* vim: set ts=8 sw=8 sts=8 noet tw=78:
+ *
+ * tup - A file-based build system
+ *
+ * Copyright (C) 2010-2012  Mike Shal <marfey@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+typedef struct
+{
+	const char *module;
+	const char *name;
+	void *new_proc;
+	void **orig_proc;
+	int skip;
+} patch_entry;

--- a/src/dllinject/trace.c
+++ b/src/dllinject/trace.c
@@ -1,0 +1,55 @@
+/* vim: set ts=8 sw=8 sts=8 noet tw=78:
+ *
+ * tup - A file-based build system
+ *
+ * Copyright (C) 2010  James McKaskill
+ * Copyright (C) 2010-2012  Mike Shal <marfey@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "trace.h"
+#include <stdio.h>
+#include <stdarg.h>
+
+
+const char* access_type_name[] = {
+	"read",
+	"write",
+	"rename",
+	"unlink",
+	"var",
+};
+
+FILE *debugf = NULL;
+int opening = 0;
+
+void debug_hook(const char* format, ...)
+{
+	char buf[256];
+	va_list ap;
+	if(debugf == NULL && !opening) {
+		opening = 1;
+		debugf = fopen("c:\\Users\\forester\\ok.txt", "a");
+		fflush(stdout);
+	}
+	if(debugf == NULL) {
+		printf("No file :(\n");
+		return;
+	}
+	va_start(ap, format);
+	vsnprintf(buf, 255, format, ap);
+	buf[255] = '\0';
+	fprintf(debugf, buf);
+	fflush(debugf);
+}

--- a/src/dllinject/trace.h
+++ b/src/dllinject/trace.h
@@ -1,0 +1,30 @@
+/* vim: set ts=8 sw=8 sts=8 noet tw=78:
+ *
+ * tup - A file-based build system
+ *
+ * Copyright (C) 2010  James McKaskill
+ * Copyright (C) 2010-2012  Mike Shal <marfey@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#pragma once
+
+#ifndef NDEBUG
+#	define DEBUG_HOOK debug_hook
+
+extern const char* access_type_name[];
+void debug_hook(const char* format, ...);
+#else
+#	define DEBUG_HOOK(...)
+#endif


### PR DESCRIPTION
Original IAT patching approach have a drawback of not intercepting
function calls done dynamically (i.e. GetProcAddress->call). Also it
requires all variants of the function to be hooked instead of single
base one making whole process open to calls not visible to hook.

This fix implements "hot patching" hooking method which inserts redirection
instructions directly to function body if the function is compiled with
"hot patching" compiler switches on. Most functions on recent Windows
versions have this option enabled.

However not all API functions support this method, therefore IAT and hot
patching are both enabled for now. In first pass hot patching redirection
is applied, and then functions which cannot be hooked using redirection are
then patched in import tables (IAT).

In overall this makes hooking much stable for me when using old MingW
/Cygwin tool builds. In long run  IAT patching can be probably dropped
allowing to greatly simplify dllinject.c but that would require
re-organizing list of patched functions.

As a side-effect dllinject.c was refactored a bit into multiple modules.
