### PR TITLE
Fixed fopen with "rb+" mode was always considered as write operation

### DIFF
--- a/src/dllinject/dllinject.c
+++ b/src/dllinject/dllinject.c
@@ -1380,14 +1380,17 @@ int _access_hook(const char *pathname, int mode)
 
 FILE *fopen_hook(const char *path, const char *mode)
 {
-	if(strchr(mode, 'w') == NULL &&
-	   strchr(mode, 'a') == NULL &&
-	   strchr(mode, '+') == NULL) {
-		handle_file(path, NULL, ACCESS_READ);
-	} else {
-		handle_file(path, NULL, ACCESS_WRITE);
-	}
-	return fopen_orig(path, mode);
+    DEBUG_HOOK("fopen mode = %s\n", mode );
+
+    FILE *ret = fopen_orig(path, mode);
+    if(strchr(mode, 'w') == NULL &&
+       strchr(mode, 'a') == NULL &&
+       ( strchr(mode, '+') == NULL || ret == NULL ) ) {
+        handle_file(path, NULL, ACCESS_READ);
+    } else {
+        handle_file(path, NULL, ACCESS_WRITE);
+    }
+    return ret;
 }
 
 int rename_hook(const char *oldpath, const char *newpath)


### PR DESCRIPTION
by hook even if file does not exist and open fails.
Some MingW gcc builds are trying to open some kind of database files
this way (.gcda code coverage?) near output files.
