### PR TITLE
Fixed win32 API hooks were not preserving GetLastError() value

### DIFF
--- a/src/dllinject/dllinject.c
+++ b/src/dllinject/dllinject.c
@@ -57,6 +57,8 @@ FILE *debugf = NULL;
 int opening = 0;
 static void debug_hook(const char* format, ...)
 {
+	DWORD save_error = GetLastError();
+
 	char buf[256];
 	va_list ap;
 	if(debugf == NULL && !opening) {
@@ -66,13 +68,16 @@ static void debug_hook(const char* format, ...)
 	}
 	if(debugf == NULL) {
 		printf("No file :(\n");
-		return;
+		goto exit;
 	}
 	va_start(ap, format);
 	vsnprintf(buf, 255, format, ap);
 	buf[255] = '\0';
 	fprintf(debugf, buf);
 	fflush(debugf);
+
+exit:;
+	SetLastError( save_error );
 }
 #else
 #	define DEBUG_HOOK(...)
@@ -1699,6 +1704,8 @@ static int canon_path(const char *file, char *dest)
 
 static void mhandle_file(const char* file, const char* file2, enum access_type at, int line)
 {
+	DWORD save_error = GetLastError();
+
 	char buf[ACCESS_EVENT_MAX_SIZE];
 	struct access_event* e = (struct access_event*) buf;
 	char* dest = (char*) (e + 1);
@@ -1706,7 +1713,7 @@ static void mhandle_file(const char* file, const char* file2, enum access_type a
 	if(line) {}
 
 	if (ignore_file(file) || ignore_file(file2) || deph == INVALID_HANDLE_VALUE)
-		return;
+		goto exit;
 
 	e->at = at;
 
@@ -1724,10 +1731,15 @@ static void mhandle_file(const char* file, const char* file2, enum access_type a
 	ret = writef((char*) e, dest - (char*) e);
 	DEBUG_HOOK("writef %d\n", ret);
 	if(ret) {}
+
+exit:;
+	SetLastError( save_error );
 }
 
 static void handle_file_w(const wchar_t* file, const wchar_t* file2, enum access_type at)
 {
+	DWORD save_error = GetLastError();
+
 	char buf[ACCESS_EVENT_MAX_SIZE];
 	char afile[PATH_MAX];
 	char afile2[PATH_MAX];
@@ -1739,7 +1751,7 @@ static void handle_file_w(const wchar_t* file, const wchar_t* file2, enum access
 	int count;
 
 	if (ignore_file_w(file) || ignore_file_w(file2) || deph == INVALID_HANDLE_VALUE)
-		return;
+		goto exit;
 
 	e->at = at;
 
@@ -1760,6 +1772,9 @@ static void handle_file_w(const wchar_t* file, const wchar_t* file2, enum access
 	ret = writef((char*) e, dest - (char*) e);
 	DEBUG_HOOK("writef [wide] %d\n", ret);
 	if(ret) {}
+
+exit:;
+	SetLastError( save_error );
 }
 
 static int open_file(const char *depfilename)


### PR DESCRIPTION
causing applications to get confused on errors.

For example in my scenario MingW was trying to get information regarding
include folders, but was using buffers which are too small to fit all
information, win32 API was reporting this, but error code was lost in
hook, causing MingW to think that API call failed due to unknown failure
instead of retrying call with bigger buffer.
