### PR TITLE
Fixed get_relative_dir() was using POSIX path separators when generating

### DIFF
--- a/src/tup/entry.c
+++ b/src/tup/entry.c
@@ -751,7 +751,7 @@ int get_relative_dir(char *dest, tupid_t start, tupid_t end, int *len)
 			first = 1;
 		} else {
 			if(dest)
-				sprintf(dest + *len, "/");
+				sprintf(dest + *len, PATH_SEP_STR);
 			(*len)++;
 		}
 		if(dest)
@@ -763,7 +763,7 @@ int get_relative_dir(char *dest, tupid_t start, tupid_t end, int *len)
 			first = 1;
 		} else {
 			if(dest)
-				sprintf(dest + *len, "/");
+				sprintf(dest + *len, PATH_SEP_STR);
 			(*len)++;
 		}
 		if(dest)


### PR DESCRIPTION
relative directory string on win32.

Windows shell (cmd.exe) in most cases treats slashes as start of command
parameters, thus making get_relative_dir()-derived paths unusable for
usage in shell scripts on win32.
