### PR TITLE
Fix for += in builtins

### DIFF
--- a/src/lua/lparser.c
+++ b/src/lua/lparser.c
@@ -1145,18 +1145,21 @@ static void append_assignment (LexState *ls, struct LHS_assign *lh) {
   expdesc mfunc;
   expdesc var;
   expdesc value;
+  expdesc env;
   TString *ts;
   int reg;
 
   luaX_next(ls);
 
   checknext(ls, '=');
-
+  
   /* Most of the actual work is done by tup_append_assignment in the
    * builtin.lua file.
    */
   ts = luaS_new(ls->L, "tup_append_assignment");
   codestring(ls, &tup_append, ts);
+  singlevaraux(fs, ls->envn, &env, 1);  /* get environment variable */
+  lua_assert(env.k == VLOCAL || env.k == VUPVAL);
 
   /* Grab a free register for the tup_append_assignment function call */
   reg = fs->freereg;
@@ -1166,7 +1169,8 @@ static void append_assignment (LexState *ls, struct LHS_assign *lh) {
    * tup_append.
    */
   init_exp(&mfunc, VNONRELOC, reg);
-  luaK_codeABC(fs, OP_GETTABUP, mfunc.u.info, 0, luaK_exp2RK(fs, &tup_append));
+  luaK_codeABC(fs, OP_GETTABUP, mfunc.u.info, env.u.info, 
+	       luaK_exp2RK(fs, &tup_append));
 
   /* First value on register stack after the function call is our variable that
    * we are appending to.

--- a/src/luabuiltin/builtin.lua
+++ b/src/luabuiltin/builtin.lua
@@ -258,14 +258,7 @@ tup.foreach_rule = function(a, b, c)
 	end
 
 	for k, v in ipairs(newinput) do
-		local moreoutputs = tup.frule{input = v, command = command, output = output}
-		if moreoutputs then
-			for ok, ov in ipairs(moreoutputs) do
-				table.insert(routputs, ov)
-			end
-		end
-		-- TODO: Why doesn't this work?
---		routputs += tup.frule{input = v, command = command, output = output}
+		routputs += tup.frule{input = v, command = command, output = output}
 	end
 	return routputs
 end


### PR DESCRIPTION
It looks like you need to make ENV_ references explicit since it doesn't necessarily appear in upvals and may appear at any index in there.  I think singlevaraux provides an example of grabbing ENV.

This reproduces the issue:

``` lua
local x = '0'
function y()
    x = '1'
    local z
    z += x
end
```
