### PR TITLE
Fix concurrent stack modification

### DIFF
--- a/src/tup/luaparser.c
+++ b/src/tup/luaparser.c
@@ -146,13 +146,21 @@ static void tuplua_register_function(struct lua_State *ls, const char *name, lua
 static int tuplua_function_include(lua_State *ls)
 {
 	struct tupfile *tf = lua_touserdata(ls, lua_upvalueindex(1));
+	lua_State *oldls = tf->ls;
 	const char *file = NULL;
 
 	file = tuplua_tostring(ls, -1);
 	if(file == NULL)
 		return luaL_error(ls, "Must be passed a filename as an argument.");
-	if(include_file(tf, file) < 0)
+
+	tf->ls = ls;
+	if(include_file(tf, file) < 0) {
+		tf->ls = oldls;
 		return luaL_error(ls, "Failed to include file \"%s\".", file);
+	}
+	tf->ls = oldls;
+	lua_pop(ls, 1);
+
 	return 0;
 }
 


### PR DESCRIPTION
This uses the correct stack to prevent concurrent stack modification when recursively loading files.  The example is a little contrived - it mirrors a situation with my own Tupfiles... There's probably something more illustrative but I'm not sure I fully understand the consequences of the bug.

The test was:
a.lua:

``` lua
x()
```

Tuprules.lua:

``` lua
tup.include 'a.lua'
```

Tupfile.lua:

``` lua
```

It printed:

```
tup error: Failed to execute a.lua:
error in error handling
tup error: Failed to parse included file 'a.lua'
tup error: Failed to execute Tuprules.lua:
[string "Tuprules.lua"]:1: Failed to include file "a.lua".
stack traceback:
    [C]: in function 'include'
    [string "Tuprules.lua"]:1: in main chunk
tup error: Failed to parse included file 'Tuprules.lua'
```

a.lua produces an error either way, but it shouldn't say "error in error handling"
