### PR TITLE
Fixes state pollution in tup.include'd tupfiles, was preventing error ha...

### DIFF
--- a/src/tup/luaparser.c
+++ b/src/tup/luaparser.c
@@ -146,13 +146,18 @@ static void tuplua_register_function(struct lua_State *ls, const char *name, lua
 static int tuplua_function_include(lua_State *ls)
 {
 	struct tupfile *tf = lua_touserdata(ls, lua_upvalueindex(1));
-	const char *file = NULL;
+	char *file = NULL;
 
-	file = tuplua_tostring(ls, -1);
+	file = tuplua_strdup(ls, -1);
+	lua_pop(ls, 1);
 	if(file == NULL)
 		return luaL_error(ls, "Must be passed a filename as an argument.");
-	if(include_file(tf, file) < 0)
-		return luaL_error(ls, "Failed to include file \"%s\".", file);
+	if(include_file(tf, file) < 0) {
+		lua_pushfstring(ls, "Failed to include file \"%s\".", file);
+		free(file);
+		return lua_error(ls);
+	}
+	free(file);
 	return 0;
 }
 


### PR DESCRIPTION
This pops file in tup.include before descending into the other parsing functions, since it was causing other stack values to be offset later.

The test was:
a.lua:

``` lua
x()
```

Tupfile.lua:

``` lua
tup.include 'a.lua'
```

It printed:

```
tup error: Failed to execute a.lua:
error in error handling
tup error: Failed to parse included file 'a.lua'
tup error: Failed to execute Tupfile.lua:
[string "Tupfile.lua"]:1: Failed to include file "a.lua".
stack traceback:
    [C]: in function 'include'
    [string "Tupfile.lua"]:1: in main chunk
```

a.lua produces an error either way, but it shouldn't say "error in error handling"
