### PR TITLE
Fix unterminated string when inputs are empty

### DIFF
--- a/src/tup/luaparser.c
+++ b/src/tup/luaparser.c
@@ -187,6 +187,7 @@ static int tuplua_table_to_string(lua_State *ls, const char *table, struct tupfi
 		perror("malloc");
 		return -1;
 	}
+	*res = '\0';
 	*out = res;
 	lua_getfield(ls, 1, table);
 	lua_pushnil(ls);


### PR DESCRIPTION
I was getting the error:

```
[ tup ] [0.120s] Scanning filesystem...
[ tup ] [0.229s] Reading in new environment variables...
[ tup ] [0.347s] Parsing Tupfiles...
* 1) [0.002s] .
tup error: Explicitly named file '??' not found in subdir '.'
tup error: Failed to execute Tupfile.lua:
[string "Tupfile.lua"]:1: Failed to define rule.
stack traceback:
    [C]: in function 'definerule'
    [string "Tupfile.lua"]:1: in main chunk
 [ ] 100%
 *** tup: 1 job failed.
```

for:

``` lua
tup.definerule{inputs = {}, outputs = {'hey'}, command = 'echo hey > hey'}
```

Also, I noticed there's no warning if outputs isn't a table.  It might be nice to have that error out, unless there's some reason you didn't want to.
