### PR TITLE
Stop compiling builtins before embedding.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,9 +62,9 @@ echo "  link luac"
 $CC *.o -o luac $LDFLAGS
 rm luac.o
 
-./luac -o builtin.luac ../src/luabuiltin/builtin.lua
+cp ../src/luabuiltin/builtin.lua builtin.lua
 mkdir luabuiltin
-xxd -i builtin.luac luabuiltin/luabuiltin.h
+xxd -i builtin.lua luabuiltin/luabuiltin.h
 
 for i in ../src/tup/*.c ../src/tup/tup/main.c ../src/tup/monitor/null.c ../src/tup/flock/fcntl.c ../src/tup/server/fuse*.c ../src/tup/server/master_fork.c ../src/inih/ini.c $plat_files; do
 	echo "  bootstrap CC $CFLAGS $i"

--- a/src/luabuiltin/Tupfile
+++ b/src/luabuiltin/Tupfile
@@ -1,3 +1,2 @@
 include_rules
-: ../lua/luac |> %f -o %o builtin.lua |> builtin.luac
-: builtin.luac |> xxd -i %f %o |> luabuiltin.h
+: builtin.lua |> xxd -i %f %o |> luabuiltin.h

--- a/src/tup/luaparser.c
+++ b/src/tup/luaparser.c
@@ -658,7 +658,7 @@ int parse_lua_tupfile(struct tupfile *tf, struct buf *b, const char *name, int t
 		lua_getglobal(ls, "debug");
 		lua_getfield(ls, -1, "traceback");
 		lua_remove(ls, -2);
-		if(luaL_loadbuffer(ls, (char *)builtin_luac, builtin_luac_len, "builtin") != LUA_OK) {
+		if(luaL_loadbuffer(ls, (char *)builtin_lua, builtin_lua_len, "builtin") != LUA_OK) {
 			fprintf(tf->f, "tup error: Failed to open builtins:\n%s\n", tuplua_tostring(ls, -1));
 			lua_close(ls);
 			tf->ls = NULL;


### PR DESCRIPTION
I was getting an error message about incompatible bytecode (I'm not sure what the exact message was) testing on a Windows 7 machine.  I think it's because of architectural differences between 64 bit Linux and 64 bit Windows.  This skips compiling and just embeds the whole builtin.lua.

Originally, I saw the 3.2 manual which stated the bytecode was fully portable, but on further investigation it seems that they've repeatedly reduced portability guarantees in successive versions.
