### PR TITLE
builtin tostring blocks metatable __tostring method

### DIFF
--- a/src/luabuiltin/builtin.lua
+++ b/src/luabuiltin/builtin.lua
@@ -21,7 +21,7 @@
 
 local realtostring = tostring
 function tostring(t)
-	if type(t) == 'table' then
+	if type(t) == 'table' and not getmetatable(t) then
 		return table.concat(t, ' ')
 	end
 	return realtostring(t)


### PR DESCRIPTION
I added a check for a metatable to disable the new default.  I figure this is acceptable since, 

If the metatable doesn't have a __tostring method, the new default behavior is still disabled.  I figure this is desirable since it also provides a mechanism to intentionally disable the new default.  Having a default tostring method for tables can obscure errors relating to mismatched types.

Also, in the case that someone has gone through the trouble to add a metatable, adding a __tostring method is trivial.
