### PR TITLE
Use root-relative paths in parse-traversal related errors/tracebacks

### DIFF
--- a/src/tup/entry.c
+++ b/src/tup/entry.c
@@ -704,7 +704,7 @@ void free_tent_list(struct tent_list_head *head)
  * root tent, meaning that the returned list of tents isn't a correct parent
  * list, but when converted to a path it will refer to the correct file.
  */
-static int get_full_path_tents(tupid_t tupid, struct tent_list_head *head)
+int get_full_path_tents(tupid_t tupid, struct tent_list_head *head)
 {
 	struct tup_entry *tent;
 	struct tent_list *tlist;

--- a/src/tup/entry.h
+++ b/src/tup/entry.h
@@ -99,6 +99,7 @@ TAILQ_HEAD(tent_list_head, tent_list);
 
 void del_tent_list_entry(struct tent_list_head *head, struct tent_list *tlist);
 void free_tent_list(struct tent_list_head *head);
+int get_full_path_tents(tupid_t tupid, struct tent_list_head *head);
 int get_relative_dir(char *dest, tupid_t start, tupid_t end, int *len);
 
 #endif


### PR DESCRIPTION
Since they were closely related, I stuck two changes in here.
1. I made the traceback and tup tree traversal related errors use root-relative paths.
2. I added a lua function that returns a root-relative path given a (valid) relative path within the tup tree.

I described my rationale for point 1 in #118.

For 2, this has been something I wanted for a while but I can't remember why at the moment.  One reason I wanted it was to implement include guards, which requires absolute path names for included files for comparison purposes.  I managed to do it with getcwd() and some regexp's, but it was pretty painful.  

Another reason I was thinking it would be helpful is for emulating variants: either by putting the tupfiles in the variant directory and defining inputs based on the current root-relative-path minus the variant directory prefix, or, if extradirectory outputs are supported, by defining outputs based on the current root-relative-path plus the variant directory prefix.

In any case, I think 2 is helpful for debugging tupfiles, path logic, etc.
