### PR TITLE
tup.include relative path with variant incorrect #2

### DIFF
--- a/src/tup/luaparser.c
+++ b/src/tup/luaparser.c
@@ -809,6 +809,7 @@ static int include_file(struct tupfile *tf, const char *file)
 	struct tup_entry *oldtent = tf->curtent;
 	int old_dfd = tf->cur_dfd;
 	struct tup_entry *srctent = NULL;
+	struct tup_entry *newtent;
 
 	if(get_path_elements(file, &pg) < 0)
 		goto out_err;
@@ -828,7 +829,12 @@ static int include_file(struct tupfile *tf, const char *file)
 		goto out_del_pg;
 	}
 
-	tf->curtent = tup_entry_get(newdt);
+	newtent = tup_entry_get(newdt);
+	if(tup_entry_variant(newtent) != tf->variant) {
+		fprintf(tf->f, "tup error: Unable to include file '%s' since it is outside of the variant tree.\n", file);
+		return -1;
+	}
+	tf->curtent = newtent;
 
 	if(variant_get_srctent(tf->variant, newdt, &srctent) < 0)
 		return -1;
@@ -840,7 +846,7 @@ static int include_file(struct tupfile *tf, const char *file)
 	}
 
 	tf->cur_dfd = tup_entry_openat(tf->root_fd, tent->parent);
-	if(tf->cur_dfd < 0) {
+	if (tf->cur_dfd < 0) {
 		parser_error(tf, file);
 		goto out_free_pel;
 	}
@@ -876,6 +882,7 @@ out_err:
 	tf->curtent = oldtent;
 	tf->cur_dfd = old_dfd;
 	if(rc < 0) {
+		fprintf(tf->f, "tup error: Failed to parse included file '%s'\n", file);
 		return -1;
 	}
 


### PR DESCRIPTION
The original change didn't affect the lua code.  This commit just copies the changes over.  I tested it and it seems to work for lua now as well.
