### PR TITLE
Add 'error' command to Tupfiles

### DIFF
--- a/tup.1
+++ b/tup.1
@@ -489,6 +489,9 @@ Toggles the true/false-ness of the previous if-statement.
 .B endif
 Ends the previous ifeq/ifdef/ifndef. Note that only 8 levels of nesting if-statements is supported.
 .TP
+.B error [message]
+Causes tup to stop parsing and fail, printing \fBmessage\fP to the user as explanation.
+.TP
 .B !macro = [inputs] | [order-only inputs] |> command |> [outputs]
 Set the !-macro to the given command string. This syntax is very similar to the :-rule, since a !-macro is basically a macro for those rules. The !-macro is not expanded until it is used in the command string of a :-rule. As such, the primary use of the !-macro is to have a place to store command strings with %-flags that may be re-used. For example, we could have a !cc macro in a top-level Tuprules.tup file like so:
 .nf


### PR DESCRIPTION
It is useful to be able to express build option configuration errors in
Tupfiles. For example, if a project requires a variant to be set, but
there is no reasonable default, the top-level Tupfile could include:

```
ifndef PLATFORM
error The variable PLATFORM must be defined. Did you forget to set up a variant?
endif
```

I did not include analogous directives 'warning' and 'info' frequently
found in other build systems as they do not intrinsically make as much
sense; should they print every time, or only when the relevant Tupfile has
changed? 'error', however, is clear as it forces the parser to fail.

I played with a few different styles of output to both (i) look good, and
(ii) differentiate itself from a tup usage error (e.g. a syntax error),
but I'm not strongly attached to it.
