### PR TITLE
Print indication when waiting for another tup instance

### DIFF
--- a/src/tup/flock.h
+++ b/src/tup/flock.h
@@ -23,6 +23,7 @@
 
 /* Wrappers for fcntl */
 int tup_flock(int fd);
+int tup_try_flock(int fd); /* Returns: -1 error, 0 got lock, 1 would block */
 int tup_unflock(int fd);
 int tup_wait_flock(int fd);
 

--- a/src/tup/flock/fcntl.c
+++ b/src/tup/flock/fcntl.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <errno.h>
 
 int tup_flock(int fd)
 {
@@ -33,6 +34,25 @@ int tup_flock(int fd)
 	};
 
 	if(fcntl(fd, F_SETLKW, &fl) < 0) {
+		perror("fcntl F_WRLCK");
+		return -1;
+	}
+	return 0;
+}
+
+/* Returns: -1 error, 0 got lock, 1 would block */
+int tup_try_flock(int fd)
+{
+	struct flock fl = {
+		.l_type = F_WRLCK,
+		.l_whence = SEEK_SET,
+		.l_start = 0,
+		.l_len = 0,
+	};
+
+	if(fcntl(fd, F_SETLK, &fl) < 0) {
+		if (errno == EAGAIN)
+			return 1;
 		perror("fcntl F_WRLCK");
 		return -1;
 	}

--- a/src/tup/flock/lock_file.c
+++ b/src/tup/flock/lock_file.c
@@ -39,6 +39,31 @@ int tup_flock(int fd)
 	return 0;
 }
 
+/* Returns: -1 error, 0 got lock, 1 would block */
+int tup_try_flock(int fd)
+{
+	HANDLE h;
+	long int tmp;
+	OVERLAPPED wtf;
+
+	tmp = _get_osfhandle(fd);
+	h = (HANDLE)tmp;
+
+	memset(&wtf, 0, sizeof(wtf));
+	if(LockFileEx(h, LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &wtf) == 0) {
+		DWORD last_error;
+
+		last_error = GetLastError();
+		if (last_error == ERROR_IO_PENDING) {
+			errno = EAGAIN;
+			return 1;
+		}
+		errno = EIO;
+		return -1;
+	}
+	return 0;
+}
+
 int tup_unflock(int fd)
 {
 	HANDLE h;

--- a/src/tup/lock.c
+++ b/src/tup/lock.c
@@ -81,12 +81,19 @@ static int tri_lock;
 
 int tup_lock_init(void)
 {
+	int ret;
+
 	sh_lock = openat(tup_top_fd(), TUP_SHARED_LOCK, O_RDWR);
 	if(sh_lock < 0) {
 		perror(TUP_SHARED_LOCK);
 		return -1;
 	}
-	if(tup_flock(sh_lock) < 0) {
+	ret = tup_try_flock(sh_lock);
+	if(ret > 0) {
+		printf("Waiting for another tup process (or an autoupdate) to finish...\n");
+		ret = tup_flock(sh_lock);
+	}
+	if(ret < 0) {
 		return -1;
 	}
 


### PR DESCRIPTION
If another instance of tup is running somewhere (e.g. an autoupdating
monitor), running a second instance of tup will wait silently until the
first process finishes. This can be confusing and make users think that
tup has hung for some reason.

This commit adds a tup_try_flock method that allows tup to print a
message indicating why it's waiting.

The windows code is untested (don't have a box to test), but if my
reading for the MSDN docs is correct, it should work. It's not a very
complicated bit of code.
