### PR TITLE
Lua documentation fixes

### DIFF
--- a/docs/html/lua_parser.html
+++ b/docs/html/lua_parser.html
@@ -33,7 +33,7 @@
 	<dd>
 		<div class="spec"><em>Returns</em>: table of strings</div>
 		<p>A wrapper for <span class="cmd">tup.definerule</span> that performs substitutions on all parameters based on format patterns.  Returns a table containing the filenames of all outputs.</p>
-		<p>If there is a single input, it can be specified as a string argument <span class="cmd">input</span> or <span class="cmd">inputs</span>, and a single output can be specified as string argument <span class="cmd">output</span> or <span class="cmd">outputs</span>.  In addition to sequential, numerically indexed elements, <span class="cmd">input</span> can contain a table at index <span class="cmd">'extra_inputs'</span>, the elements of which are treated like normal inputs but are not used when susbtituting <span class="cmd">%f</span>.</p>
+		<p>If there is a single input, it can be specified as a string argument <span class="cmd">input</span>, and a single output can be specified as string argument <span class="cmd">output</span>.  In addition to sequential, numerically indexed elements, <span class="cmd">input</span> can contain a table at index <span class="cmd">'extra_inputs'</span>, the elements of which are treated like normal inputs but are not used when susbtituting <span class="cmd">%f</span>.</p>
 		<p>The substitutions are roughly the same as the substitutions in non-Lua Tupfile rules.  See the <a href="http://gittup.org/tup/manual.html">Tup manual</a> for more information on the format patterns.</p>
 		<ul>
 			<li>If a glob character appears in an input, the input string is replaced by its glob results.</li>


### PR DESCRIPTION
Just a couple small documentation fixes.  I might have been mistaken about the "inputs" and "outputs" frule parameters taking flat strings rather than tables - when I tested it just now it didn't work.

I'm stepping on @gz's toes here, sorry.  I was remiss about PRing the commands change.

Edit: Sorry, I also didn't see your pull request @gz.
