### PR TITLE
Add support for Mac OS X 10.10 (Yosemite)

### DIFF
--- a/src/compat/macosx.h
+++ b/src/compat/macosx.h
@@ -25,7 +25,8 @@
 #include <sys/stat.h>
 #include <dirent.h>
 
-/* MacOSX 10.6 does not have *at() functions */
+/* MacOSX 10.6 does not have *at() functions, but MacOSX 10.10 adds them */
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101000
 DIR *fdopendir(int fd);
 int faccessat(int dirfd, const char *pathname, int mode, int flags);
 int fchmodat(int dirfd, const char *pathname, mode_t mode, int flags);
@@ -41,5 +42,6 @@ int utimensat(int dirfd, const char *pathname, const struct timespec times[2], i
 
 /* clearenv also seems to be missing */
 int clearenv(void);
+#endif
 
 #endif

--- a/src/compat/readlinkat.c
+++ b/src/compat/readlinkat.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include "dir_mutex.h"
 
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101000
 int readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz)
 {
 	int rc;
@@ -32,3 +33,4 @@ int readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz)
 	dir_mutex_unlock();
 	return rc;
 }
+#endif


### PR DESCRIPTION
* The compat file is no longer needed but removing it for Yosemite and
  keeping for other versions of Mac OS X is cumbersome. Instead, using
  the C preprocessor to remove the function declarations.
* The readlinkat code conflicts with 10.10 system headers (int instead
  of size_t). Since it works as-is on other OS X versions, the same
  preprocessor macro is used to remove it in 10.10.

I am not sure why the other .c files for *at functions do not need to be changed for Yosemite support.