### PR TITLE
Turn on close-on-exec flag on file descriptors.

### DIFF
--- a/src/tup/flock/fcntl.c
+++ b/src/tup/flock/fcntl.c
@@ -30,7 +30,7 @@ int tup_lock_open(const char *lockname, tup_lock_t *lock)
 {
 	int fd;
 
-	fd = openat(tup_top_fd(), lockname, O_RDWR);
+	fd = openat(tup_top_fd(), lockname, O_RDWR|O_CLOEXEC);
 	if(fd < 0) {
 		perror(lockname);
 		fprintf(stderr, "tup error: Unable to open lockfile.\n");

--- a/src/tup/monitor/inotify.c
+++ b/src/tup/monitor/inotify.c
@@ -203,7 +203,7 @@ int monitor(int argc, char **argv)
 		return -1;
 	}
 
-	inot_fd = inotify_init();
+	inot_fd = inotify_init1(IN_CLOEXEC);
 	if(inot_fd < 0) {
 		perror("inotify_init");
 		return -1;

--- a/src/tup/server/master_fork.c
+++ b/src/tup/server/master_fork.c
@@ -452,7 +452,7 @@ static int master_fork_loop(void)
 			return -1;
 		if(read_all(msd[0], vardict_file, em.vardictlen) < 0)
 			return -1;
-		vardict_fd = open(vardict_file, O_RDONLY);
+		vardict_fd = open(vardict_file, O_RDONLY|O_CLOEXEC);
 		if(vardict_fd < 0) {
 			if(errno != ENOENT) {
 				perror(vardict_file);


### PR DESCRIPTION
Tup leaves a handful of file descriptors open when forking the rule commands. It would be better if those file descriptors where closed in the child processes, and the child only had open file descriptors 0, 1 and 2 as expected by a UNIX process.

To see the open file descriptors, run the simple rule:

    : |> ls -l /proc/self/fd | tee  %o |> ls_output

On my machine, the output looks like:

```
total 0
lr-x------ 1 gus gus 64 Oct 21 23:14 0 -> /dev/null
l-wx------ 1 gus gus 64 Oct 21 23:14 1 -> pipe:[9611523]
l-wx------ 1 gus gus 64 Oct 21 23:14 2 -> /home/gus/Development/.tup/tmp/output-2719
lr-x------ 1 gus gus 64 Oct 21 23:14 3 -> /home/gus/Development/
lr-x------ 1 gus gus 64 Oct 21 23:14 4 -> anon_inode:inotify
lrwx------ 1 gus gus 64 Oct 21 23:14 5 -> /home/gus/Development/.tup/shared
lrwx------ 1 gus gus 64 Oct 21 23:14 6 -> /home/gus/Development/.tup/object
lrwx------ 1 gus gus 64 Oct 21 23:14 7 -> /home/gus/Development/.tup/tri
lr-x------ 1 gus gus 64 Oct 21 23:14 8 -> /proc/21144/fd
lr-x------ 1 gus gus 64 Oct 21 23:14 9 -> /home/gus/Development/.tup/vardict-build-debug
```

This patch applies the close-on-exec flag to some of the file descriptors. In my (limited) testing, it gets rid of all the extra open file descriptors, except when tup is running as a monitor. In that later case, the vardict file descriptor remains open.