### PR TITLE
solved the readlinkat type conflict error on mac osx

### DIFF
--- a/src/compat/macosx.h
+++ b/src/compat/macosx.h
@@ -33,7 +33,7 @@ int fchownat(int dirfd, const char *pathname, uid_t owner, gid_t group, int flag
 int fstatat(int dirfd, const char *pathname, struct stat *buf, int flags);
 int mkdirat(int dirfd, const char *pathname, mode_t mode);
 int openat(int dirfd, const char *pathname, int flags, ...);
-int readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz);
+int readlinkat1(int dirfd, const char *pathname, char *buf, size_t bufsiz);
 int renameat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath);
 int symlinkat(const char *oldpath, int newdirfd, const char *newpath);
 int unlinkat(int dirfd, const char *pathname, int flags);

--- a/src/compat/readlinkat.c
+++ b/src/compat/readlinkat.c
@@ -23,7 +23,7 @@
 #include <unistd.h>
 #include "dir_mutex.h"
 
-int readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz)
+int readlinkat1(int dirfd, const char *pathname, char *buf, size_t bufsiz)
 {
 	int rc;
 

--- a/src/compat/win32/mingw.h
+++ b/src/compat/win32/mingw.h
@@ -32,7 +32,7 @@ int fstatat(int dirfd, const char *pathname, struct stat *buf, int flags);
 int mkstemp(char *template);
 int openat(int dirfd, const char *pathname, int flags, ...);
 int unlinkat(int dirfd, const char *pathname, int flags);
-int readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz);
+int readlinkat1(int dirfd, const char *pathname, char *buf, size_t bufsiz);
 int mkdirat(int dirfd, const char *pathname, mode_t mode);
 int renameat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath);
 int symlink(const char *oldpath, const char *newpath);

--- a/src/compat/win32/readlinkat.c
+++ b/src/compat/win32/readlinkat.c
@@ -20,7 +20,7 @@
 
 #include <errno.h>
 
-int readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz)
+int readlinkat1(int dirfd, const char *pathname, char *buf, size_t bufsiz)
 {
 	if(dirfd) {}
 	if(pathname) {}

--- a/src/tup/updater.c
+++ b/src/tup/updater.c
@@ -2032,13 +2032,13 @@ static int compare_links(const char *path1, const char *path2, int *eq)
 	int rc1;
 	int rc2;
 
-	rc1 = readlinkat(tup_top_fd(), path1, b1, sizeof(b1));
+	rc1 = readlinkat1(tup_top_fd(), path1, b1, sizeof(b1));
 	if(rc1 < 0) {
 		perror("readlinkat");
 		fprintf(stderr, "tup error: Unable to call readlinkat on path %s\n", path1);
 		return -1;
 	}
-	rc2 = readlinkat(tup_top_fd(), path2, b2, sizeof(b2));
+	rc2 = readlinkat1(tup_top_fd(), path2, b2, sizeof(b2));
 	if(rc2 < 0) {
 		perror("readlinkat");
 		fprintf(stderr, "tup error: Unable to call readlinkat on path %s\n", path2);


### PR DESCRIPTION
On Mac OSX 10.10, I had the following error when ./bootstrap.sh 

    In file included from /usr/include/unistd.h:72:
    /usr/include/sys/unistd.h:206:9: error: conflicting types for 'readlinkat'
    ssize_t readlinkat(int, const char *, char *, size_t)   __OSX_AVAILABLE_...
            ^
    ../src/compat/macosx.h:36:5: note: previous declaration is here
    int readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz);

This is solved by renaming the function readlinkat to readlinkat1.
