### PR TITLE
Remove logical negation in a call to tup_db_findenv.

### DIFF
--- a/src/tup/parser.c
+++ b/src/tup/parser.c
@@ -982,7 +982,7 @@ int export(struct tupfile *tf, const char *cmdline)
 	}
 
 	/* Pull from tup's environment */
-	if(!tup_db_findenv(cmdline, &tent) < 0) {
+	if(tup_db_findenv(cmdline, &tent) < 0) {
 		fprintf(tf->f, "tup error: Unable to get tup entry for environment variable '%s'\n", cmdline);
 		return -1;
 	}


### PR DESCRIPTION
GCC warned me about this while compiling, so I thought I should make a pull request. In `parser.c`:

	if(!tup_db_findenv(cmdline, &tent) < 0) {
		fprintf(tf->f, "tup error: Unable to get tup entry for environment variable '%s'\n", cmdline);
		return -1;
	}

`!tup_db_findenv(cmdline, &tent) < 0` is parsed as `(!x) < 0`, which never returns true as !x is always 0 or 1. Removing the ! correctly represents the error condition, which is tup_db_findenv returning -1.

The only thing missing is that I wasn't able to figure out how to trigger that error condition (ie. to make tup_db_findenv return -1), so I can't add a unit test for it.