### PR TITLE
the test fails if `which readlink` returns a symlink to the actual exe

### DIFF
--- a/test/t4131-proc-self-exe.sh
+++ b/test/t4131-proc-self-exe.sh
@@ -33,6 +33,6 @@ HERE
 tup touch Tupfile
 update --debug-fuse 2>~/fuse.txt
 
-echo `which readlink` | diff - file.txt
+readlink `which readlink` | diff - file.txt
 
 eotup


### PR DESCRIPTION
On my gentoo-box the default behaviour is the following:
```bash
$ which readlink
/usr/bin/readlink
$ file /usr/bin/readlink
/usr/bin/readlink: symbolic link to /bin/readlink
$ readlink /proc/self/exe
/bin/readlink
```
So we should compare `readlink $(which readlink)` rather than simply `$(which readlink)`.