### PR TITLE
Expand commands for generate scripts

### DIFF
--- a/test/t2192-generate-shell-script-expand-groups.sh
+++ b/test/t2192-generate-shell-script-expand-groups.sh
@@ -1,0 +1,34 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# Copyright (C) 2014-2015  Mike Shal <marfey@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Try to generate a shell script using a specific variant config
+
+. ./tup.sh
+check_no_windows shell
+cat > Tupfile << HERE
+: |> echo "asdf" > a |> a <foo>
+: |> echo "fdsa" > b |> b <foo>
+
+: <foo> |> cat %<foo> > c |> c
+HERE
+
+tup generate generated.sh
+./generated.sh
+check_exist . c
+
+eotup


### PR DESCRIPTION
This avoids writing commands such as

    cc %<objs> -o final_executable

to the generated build.sh script.

Addresses the issue brought up in #249.