### PR TITLE
Fix test using git init.

### DIFF
--- a/test/t8005-variant2.sh
+++ b/test/t8005-variant2.sh
@@ -30,6 +30,8 @@ echo "CONFIG_FOO=y" > build/tup.config
 tup touch build/tup.config Tupfile foo.c
 
 git init
+git config user.email test@example.com
+git config user.name test
 git add .
 git commit -m "First commit"
 git tag -a -m "First version" v0.1


### PR DESCRIPTION
If there is no global user.{name,email}, git commit will fail thus t8005-variant2 also.

Ensuring that there is indeed a set user.{name,email} will avoid this.