### PR TITLE
Add NetBSD support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,6 +44,10 @@ case "$os" in
 	plat_files="$plat_files ../src/compat/utimensat_linux.c"
 	plat_files="$plat_files ../src/compat/clearenv.c"
 	;;
+	NetBSD)
+	plat_files="$plat_files ../src/compat/dummy.c"
+	plat_files="$plat_files ../src/compat/clearenv.c"
+	;;
 esac
 
 rm -rf build

--- a/netbsd.tup
+++ b/netbsd.tup
@@ -1,0 +1,1 @@
+CFLAGS += -include compat/netbsd.h

--- a/src/bsd/queue.h
+++ b/src/bsd/queue.h
@@ -30,6 +30,25 @@
  * $FreeBSD: head/sys/sys/queue.h 221843 2011-05-13 15:49:23Z mdf $
  */
 
+#if defined(__NetBSD__)
+/* NetBSD and FreeBSD implementations differ in details.
+ * pullin the native one otherwise system headers won't build */
+#include <sys/queue.h>
+
+#ifndef LIST_SWAP /* Missed as of NetBSD-7.99.25 */
+#define LIST_SWAP(head1, head2, type, field) do {                       \
+        struct type *swap_tmp = LIST_FIRST((head1));                    \
+        LIST_FIRST((head1)) = LIST_FIRST((head2));                      \
+        LIST_FIRST((head2)) = swap_tmp;                                 \
+        if ((swap_tmp = LIST_FIRST((head1))) != NULL)                   \
+                swap_tmp->field.le_prev = &LIST_FIRST((head1));         \
+        if ((swap_tmp = LIST_FIRST((head2))) != NULL)                   \
+                swap_tmp->field.le_prev = &LIST_FIRST((head2));         \
+} while (0)
+#endif
+
+#else
+
 #ifndef _SYS_QUEUE_H_
 #define _SYS_QUEUE_H_
 
@@ -638,3 +657,5 @@ struct {                                                                \
 } while (0)
 
 #endif /* !_SYS_QUEUE_H_ */
+
+#endif /* defined(__NetBSD__) */

--- a/src/bsd/tree.h
+++ b/src/bsd/tree.h
@@ -27,6 +27,13 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if defined(__NetBSD__)
+/* NetBSD and FreeBSD implementations differ in details.
+ * pullin the native one otherwise system headers won't build */
+#include <sys/tree.h>
+
+#else
+
 #ifndef _SYS_TREE_H_
 #define _SYS_TREE_H_
 
@@ -761,3 +768,5 @@ name##_RB_MINMAX(struct name *head, int val)                            \
 	     (x) = (y))
 
 #endif  /* _SYS_TREE_H_ */
+
+#endif /* defined(__NetBSD__) */

--- a/src/compat/Tupfile
+++ b/src/compat/Tupfile
@@ -12,6 +12,11 @@ ifeq (@(TUP_PLATFORM),freebsd)
 	srcs += clearenv.c
 endif
 
+ifeq (@(TUP_PLATFORM),netbsd)
+	srcs += dummy.c
+	srcs += clearenv.c
+endif
+
 ifeq (@(TUP_PLATFORM),macosx)
 srcs += clearenv.c
 srcs += dir_mutex.c

--- a/src/compat/netbsd.h
+++ b/src/compat/netbsd.h
@@ -1,0 +1,26 @@
+/* vim: set ts=8 sw=8 sts=8 noet tw=78:
+ *
+ * tup - A file-based build system
+ *
+ * Copyright (C) 2012-2016  Mike Shal <marfey@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef tup_compat_netbsd_h
+#define tup_compat_netbsd_h
+
+int clearenv(void);
+
+#endif

--- a/src/tup/option.c
+++ b/src/tup/option.c
@@ -474,7 +474,7 @@ static const char *cpu_number(void)
 	static char buf[10];
 
 	int count = 1;
-#if defined(__linux__) || defined(__sun__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__sun__) || defined(__FreeBSD__) || defined(__NetBSD__)
 	count = sysconf(_SC_NPROCESSORS_ONLN);
 #elif defined(__APPLE__)
 	int nm[2];

--- a/src/tup/platform.c
+++ b/src/tup/platform.c
@@ -31,6 +31,8 @@ const char *tup_platform = "macosx";
 const char *tup_platform = "win32";
 #elif __FreeBSD__
 const char *tup_platform = "freebsd";
+#elif defined(__NetBSD__)
+const char *tup_platform = "netbsd";
 #else
 #error Unsupported platform. Please add support in tup/platform.c
 #endif

--- a/src/tup/server/fuse_server.c
+++ b/src/tup/server/fuse_server.c
@@ -123,6 +123,15 @@ static int os_unmount(void)
 	}
 	return rc;
 }
+#elif defined(__NetBSD__)
+static int os_unmount(void)
+{
+	if(unmount(TUP_MNT, MNT_FORCE) < 0) {
+		perror("unmount");
+		return -1;
+	}
+	return 0;
+}
 #else
 #error Unsupported platform. Please add unmounting code to fuse_server.c
 #endif

--- a/tup.1
+++ b/tup.1
@@ -661,7 +661,7 @@ In tup.config, comments are determined by a '#' character in the first column. T
 In this case, the @-variable "FOO" is explicitly set to "n".
 .TP
 .B @(TUP_PLATFORM)
-TUP_PLATFORM is a special @-variable. If CONFIG_TUP_PLATFORM is not set in the tup.config file, it has a default value according to the platform that tup itself was compiled in. Currently the default value is one of "linux", "solaris", "macosx", "win32", or "freebsd".
+TUP_PLATFORM is a special @-variable. If CONFIG_TUP_PLATFORM is not set in the tup.config file, it has a default value according to the platform that tup itself was compiled in. Currently the default value is one of "linux", "solaris", "macosx", "win32", "freebsd" or "netbsd".
 .TP
 .B @(TUP_ARCH)
 TUP_ARCH is another special @-variable. If CONFIG_TUP_ARCH is not set in the tup.config file, it has a default value according to the processor architecture that tup itself was compiled in. Currently the default value is one of "i386", "x86_64", "powerpc", "powerpc64", "ia64", "alpha", "sparc" or "arm".


### PR DESCRIPTION
I'm attaching patch adding preliminary support for NetBSD.

Our fuse implementation differs from Linux and FreeBSD and there are still some issues to be fixed. Besides the rest seems fine for now.

Build log.

```
$ sudo LD_LIBRARY_PATH=/usr/pkg/lib ./bootstrap.sh  
  mkdir build
  cd build
  bootstrap CC -g ../src/lua/lapi.c
  bootstrap CC -g ../src/lua/lauxlib.c
  bootstrap CC -g ../src/lua/lbaselib.c
  bootstrap CC -g ../src/lua/lbitlib.c
  bootstrap CC -g ../src/lua/lcode.c
  bootstrap CC -g ../src/lua/lcorolib.c
  bootstrap CC -g ../src/lua/lctype.c
  bootstrap CC -g ../src/lua/ldblib.c
  bootstrap CC -g ../src/lua/ldebug.c
  bootstrap CC -g ../src/lua/ldo.c
  bootstrap CC -g ../src/lua/ldump.c
  bootstrap CC -g ../src/lua/lfunc.c
  bootstrap CC -g ../src/lua/lgc.c
  bootstrap CC -g ../src/lua/linit.c
  bootstrap CC -g ../src/lua/liolib.c
  bootstrap CC -g ../src/lua/llex.c
  bootstrap CC -g ../src/lua/lmathlib.c
  bootstrap CC -g ../src/lua/lmem.c
  bootstrap CC -g ../src/lua/loadlib.c
  bootstrap CC -g ../src/lua/lobject.c
  bootstrap CC -g ../src/lua/lopcodes.c
  bootstrap CC -g ../src/lua/loslib.c
  bootstrap CC -g ../src/lua/lparser.c
  bootstrap CC -g ../src/lua/lstate.c
  bootstrap CC -g ../src/lua/lstring.c
  bootstrap CC -g ../src/lua/lstrlib.c
  bootstrap CC -g ../src/lua/ltable.c
  bootstrap CC -g ../src/lua/ltablib.c
  bootstrap CC -g ../src/lua/ltm.c
  bootstrap CC -g ../src/lua/lua.c
  bootstrap CC -g ../src/lua/luac.c
  bootstrap CC -g ../src/lua/lundump.c
  bootstrap CC -g ../src/lua/lvm.c
  bootstrap CC -g ../src/lua/lzio.c
  link lua
  bootstrap CC -g ../src/tup/bin.c
  bootstrap CC -g ../src/tup/colors.c
  bootstrap CC -g ../src/tup/config.c
  bootstrap CC -g ../src/tup/create_name_file.c
  bootstrap CC -g ../src/tup/db.c
  bootstrap CC -g ../src/tup/debug.c
  bootstrap CC -g ../src/tup/delete_name_file.c
  bootstrap CC -g ../src/tup/dircache.c
  bootstrap CC -g ../src/tup/entry.c
  bootstrap CC -g ../src/tup/environ.c
  bootstrap CC -g ../src/tup/estring.c
  bootstrap CC -g ../src/tup/file.c
  bootstrap CC -g ../src/tup/fslurp.c
  bootstrap CC -g ../src/tup/graph.c
  bootstrap CC -g ../src/tup/if_stmt.c
  bootstrap CC -g ../src/tup/init.c
  bootstrap CC -g ../src/tup/lock.c
  bootstrap CC -g ../src/tup/luaparser.c
  bootstrap CC -g ../src/tup/option.c
  bootstrap CC -g ../src/tup/parser.c
  bootstrap CC -g ../src/tup/path.c
  bootstrap CC -g ../src/tup/pel_group.c
  bootstrap CC -g ../src/tup/platform.c
  bootstrap CC -g ../src/tup/privs.c
  bootstrap CC -g ../src/tup/progress.c
  bootstrap CC -g ../src/tup/send_event.c
  bootstrap CC -g ../src/tup/string_tree.c
  bootstrap CC -g ../src/tup/thread_tree.c
  bootstrap CC -g ../src/tup/timespan.c
  bootstrap CC -g ../src/tup/tupid_tree.c
  bootstrap CC -g ../src/tup/updater.c
  bootstrap CC -g ../src/tup/vardb.c
  bootstrap CC -g ../src/tup/vardict.c
  bootstrap CC -g ../src/tup/variant.c
  bootstrap CC -g ../src/tup/varsed.c
  bootstrap CC -g ../src/tup/tup/main.c
  bootstrap CC -g ../src/tup/monitor/null.c
  bootstrap CC -g ../src/tup/flock/fcntl.c
  bootstrap CC -g ../src/tup/server/fuse_fs.c
  bootstrap CC -g ../src/tup/server/fuse_server.c
  bootstrap CC -g ../src/tup/server/master_fork.c
  bootstrap CC -g ../src/inih/ini.c
  bootstrap CC -g ../src/compat/dummy.c
  bootstrap CC -g ../src/compat/clearenv.c
  bootstrap CC -g ../src/sqlite3/sqlite3.c
  bootstrap LD tup -lm
[ tup ] [0.000s] Scanning filesystem...
[ tup ] [0.122s] Reading in new environment variables...
[ tup ] [0.122s] Parsing Tupfiles...
tup: perfuse_open: setsockopt SO_SNDBUF to 540672 failed: No buffer space available
tup: perfuse_open: setsockopt SO_RCVBUF to 540672 failed: No buffer space available
tup: perfuse_open: setsockopt SO_SNDBUF to 540672 failed: No buffer space available
tup: perfuse_open: setsockopt SO_RCVBUF to 540672 failed: No buffer space available
  1) [0.005s] src/lua
  2) [0.001s] src/luabuiltin
  3) [0.005s] src/tup
  4) [0.001s] src/tup/flock
  5) [0.001s] src/tup/monitor
  6) [0.002s] src/tup/server
  7) [0.001s] src/sqlite3
  8) [0.001s] src/inih
  9) [0.001s] src/compat
 10) [0.001s] src/tup/tup
 11) [0.003s] .
 12) [0.001s] contrib                                                                                                                                                                                                                       
 13) [0.001s] contrib/debian                                                                                                                                                                                                                
 14) [0.001s] contrib/debian/source                                                                                                                                                                                                         
 15) [0.001s] contrib/syntax                                                                                                                                                                                                                
 16) [0.001s] docs                                                                                                                                                                                                                          
 17) [0.001s] docs/html                                                                                                                                                                                                                     
 18) [0.001s] docs/html/pub                                                                                                                                                                                                                 
 19) [0.001s] docs/html/pub/win32                                                                                                                                                                                                           
 20) [0.001s] src                                                                                                                                                                                                                           
 21) [0.001s] src/bsd                                                                                                                                                                                                                       
 22) [0.001s] src/compat/win32                                                                                                                                                                                                              
 23) [0.001s] src/compat/win32/detect                                                                                                                                                                                                       
 24) [0.001s] src/compat/win32/sys                                                                                                                                                                                                          
 25) [0.001s] src/dllinject                                                                                                                                                                                                                 
 26) [0.001s] test                                                                                                                                                                                                                          
 27) [0.001s] test/make_v_tup                                                                                                                                                                                                               
 28) [0.001s] build                                                                                                                                                                                                                         
 29) [0.001s] build/luabuiltin                                                                                                                                                                                                              
 [   ETA~=<1s Remaining=0      ] 100%
[ tup ] [0.166s] No files to delete.                                                                                                                                                                                                        
[ tup ] [0.167s] Generating .gitignore files...
[ tup ] [0.310s] Executing Commands...
 [                           ETA~=??? Remaining=85 Active=8                            ]   0%fuse: writing device: Message too long                                                                                                         
fuse: writing device: Message too long
fuse: writing device: Message too long
fuse: writing device: Message too long
fuse: writing device: Message too long
fuse: writing device: Message too long
fuse: writing device: Message too long
fuse: writing device: Message too long
```

And it hangs forever.
