### PR TITLE
Improve hooking of Lua io library

### DIFF
--- a/src/luabuiltin/builtin.lua
+++ b/src/luabuiltin/builtin.lua
@@ -38,6 +38,12 @@ function io.open(filename, mode)
 	return unchdir_after(realioopen(filename, mode))
 end
 
+local realiolines = io.lines
+function io.lines(filename, ...)
+	tup.chdir(filename)
+	return unchdir_after(realiolines(filename, ...))
+end
+
 tup.file = function(filename)
 	-- Returns filename sans preceeding dir/'s
 	return (string.gsub(filename, '[^/\\]*[/\\]', ''))

--- a/src/luabuiltin/builtin.lua
+++ b/src/luabuiltin/builtin.lua
@@ -27,12 +27,15 @@ function tostring(t)
 	return realtostring(t)
 end
 
+local function unchdir_after(...)
+	tup.unchdir()
+	return ...
+end
+
 local realioopen = io.open
 function io.open(filename, mode)
 	tup.chdir(filename, mode)
-	local f = realioopen(filename, mode)
-	tup.unchdir()
-	return f
+	return unchdir_after(realioopen(filename, mode))
 end
 
 tup.file = function(filename)


### PR DESCRIPTION
Previously, the hooking around `io.open` caused the 2<sup>nd</sup> return value to be dropped, and the lack of hooking around `io.lines` caused dependencies to be missed. Both problems are now fixed.