### PR TITLE
Allow disabling use of namespacing features via env variable TUP_NO_NAMESPACING

### DIFF
--- a/src/tup/server/master_fork.c
+++ b/src/tup/server/master_fork.c
@@ -152,7 +152,10 @@ int server_pre_init(void)
 	}
 	if(master_fork_pid == 0) {
 #ifdef __linux__
-		if(!tup_privileged()) {
+		if(getenv("TUP_NO_NAMESPACING")) {
+			use_namespacing = 0;
+		}
+		if(!tup_privileged() && use_namespacing) {
 			uid_t origuid = getuid();
 			uid_t origgid = getgid();
 			pid_t pid = getpid();


### PR DESCRIPTION
For running tup inside of certain sandboxes (like gentoo's emerge
sandbox), we need to avoid trying to access /proc/*/setgroups. Allow
users that require this to export the environment variable
TUP_NO_NAMESPACING=1 to disable namespacing.

It might also be a good choice to allow subsequent failures in the namespace code to be soft failures like the initial `unshare()`, but that isn't quite sufficient for me on gentoo (still get sandbox violations)