### PR TITLE
Add b ^-flag to run in bash with -o pipefail

### DIFF
--- a/src/tup/server.h
+++ b/src/tup/server.h
@@ -67,7 +67,7 @@ int server_post_exit(void);
 int server_init(enum server_mode mode);
 int server_quit(void);
 int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newenv,
-		struct tup_entry *dtent, int need_namespacing);
+		struct tup_entry *dtent, int need_namespacing, int run_in_bash);
 int server_postexec(struct server *s);
 int server_is_dead(void);
 int server_config_start(struct server *s);

--- a/src/tup/server.h
+++ b/src/tup/server.h
@@ -56,6 +56,11 @@ struct parser_server {
 	pthread_mutex_t lock;
 };
 
+struct exec_flags {
+	int need_namespacing : 1;
+	int run_in_bash : 1;
+};
+
 enum server_mode {
 	SERVER_CONFIG_MODE,
 	SERVER_PARSER_MODE,
@@ -67,7 +72,7 @@ int server_post_exit(void);
 int server_init(enum server_mode mode);
 int server_quit(void);
 int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newenv,
-		struct tup_entry *dtent, int need_namespacing, int run_in_bash);
+		struct tup_entry *dtent, struct exec_flags flags);
 int server_postexec(struct server *s);
 int server_is_dead(void);
 int server_config_start(struct server *s);

--- a/src/tup/server/fuse_server.c
+++ b/src/tup/server/fuse_server.c
@@ -435,8 +435,7 @@ static int finfo_wait_open_count(struct server *s)
 }
 
 static int exec_internal(struct server *s, const char *cmd, struct tup_env *newenv,
-			 struct tup_entry *dtent, int single_output, int need_namespacing,
-			 int run_in_bash)
+			 struct tup_entry *dtent, int single_output, struct exec_flags flags)
 {
 	int status;
 	char buf[64];
@@ -448,8 +447,7 @@ static int exec_internal(struct server *s, const char *cmd, struct tup_env *newe
 	memset(&em, 0, sizeof(em));
 	em.sid = s->id;
 	em.single_output = single_output;
-	em.need_namespacing = need_namespacing;
-	em.run_in_bash = run_in_bash;
+	em.flags = flags;
 	em.envlen = newenv->block_size;
 	em.num_env_entries = newenv->num_entries;
 	em.joblen = snprintf(job, sizeof(job), TUP_MNT "/" TUP_JOB "%i", s->id) + 1;
@@ -536,7 +534,7 @@ static int exec_internal(struct server *s, const char *cmd, struct tup_env *newe
 }
 
 int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newenv,
-		struct tup_entry *dtent, int need_namespacing, int run_in_bash)
+		struct tup_entry *dtent, struct exec_flags flags)
 {
 	int rc;
 
@@ -545,7 +543,7 @@ int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newe
 	if(tup_fuse_add_group(s->id, &s->finfo) < 0)
 		return -1;
 
-	rc = exec_internal(s, cmd, newenv, dtent, 1, need_namespacing, run_in_bash);
+	rc = exec_internal(s, cmd, newenv, dtent, 1, flags);
 
 	if(tup_fuse_rm_group(&s->finfo) < 0)
 		return -1;
@@ -577,8 +575,9 @@ int server_run_script(FILE *f, tupid_t tupid, const char *cmdline,
 	s.signalled = 0;
 	s.error_mutex = NULL;
 	tent = tup_entry_get(tupid);
+	struct exec_flags flags = {0, 0};
 	init_file_info(&s.finfo, tup_entry_variant(tent)->variant_dir);
-	if(exec_internal(&s, cmdline, &te, tent, 0, 0, 0) < 0)
+	if(exec_internal(&s, cmdline, &te, tent, 0, flags) < 0)
 		return -1;
 	environ_free(&te);
 

--- a/src/tup/server/master_fork.c
+++ b/src/tup/server/master_fork.c
@@ -210,7 +210,7 @@ int server_pre_init(void)
 int server_post_exit(void)
 {
 	int status;
-	struct execmsg em = {-1, 0, 0, 0, 0, 0, 0, 0, 0};
+	struct execmsg em = {-1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 	if(!inited)
 		return 0;
@@ -664,7 +664,13 @@ static int master_fork_loop(void)
 
 			if(setup_subprocess(em.sid, job, dir, waiter->dev, waiter->proc, em.single_output, em.need_namespacing) < 0)
 				exit(1);
-			execle("/bin/sh", "/bin/sh", "-e", "-c", cmd, NULL, envp);
+
+			if(em.run_in_bash) {
+				execle("/usr/bin/env", "/usr/bin/env", "bash", "-e", "-o", "pipefail", "-c", cmd, NULL, envp);
+			} else {
+				execle("/bin/sh", "/bin/sh", "-e", "-c", cmd, NULL, envp);
+			}
+
 			perror("execl");
 			exit(1);
 		}

--- a/src/tup/server/master_fork.c
+++ b/src/tup/server/master_fork.c
@@ -20,7 +20,6 @@
 
 #define _GNU_SOURCE
 #include "master_fork.h"
-#include "tup/server.h"
 #include "tup/db_types.h"
 #include "tup/tupid_tree.h"
 #include "tup/container.h"
@@ -210,7 +209,7 @@ int server_pre_init(void)
 int server_post_exit(void)
 {
 	int status;
-	struct execmsg em = {-1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+	struct execmsg em = {-1, 0, 0, 0, 0, 0, 0, 0, {0, 0}};
 
 	if(!inited)
 		return 0;
@@ -614,7 +613,7 @@ static int master_fork_loop(void)
 		snprintf(waiter->dev, sizeof(waiter->dev), "%s/dev", job);
 		snprintf(waiter->proc, sizeof(waiter->proc), "%s/proc", job);
 #ifdef __APPLE__
-		if(full_deps || (em.need_namespacing && privileged)) {
+		if(full_deps || (em.flags.need_namespacing && privileged)) {
 			waiter->umount_dev = 1;
 		}
 #endif
@@ -662,10 +661,10 @@ static int master_fork_loop(void)
 			curp++;
 			*curp = NULL;
 
-			if(setup_subprocess(em.sid, job, dir, waiter->dev, waiter->proc, em.single_output, em.need_namespacing) < 0)
+			if(setup_subprocess(em.sid, job, dir, waiter->dev, waiter->proc, em.single_output, em.flags.need_namespacing) < 0)
 				exit(1);
 
-			if(em.run_in_bash) {
+			if(em.flags.run_in_bash) {
 				execle("/usr/bin/env", "/usr/bin/env", "bash", "-e", "-o", "pipefail", "-c", cmd, NULL, envp);
 			} else {
 				execle("/bin/sh", "/bin/sh", "-e", "-c", cmd, NULL, envp);

--- a/src/tup/server/master_fork.h
+++ b/src/tup/server/master_fork.h
@@ -21,6 +21,7 @@
 #ifndef tup_master_fork_h
 #define tup_master_fork_h
 
+#include "tup/server.h"
 #include "tup/compat.h"
 #include "tup/tupid.h"
 
@@ -35,8 +36,7 @@ struct execmsg {
 	int vardictlen;
 	int num_env_entries;
 	int single_output;
-	int need_namespacing;
-	int run_in_bash;
+	struct exec_flags flags;
 };
 
 #define JOB_MAX 64

--- a/src/tup/server/master_fork.h
+++ b/src/tup/server/master_fork.h
@@ -36,6 +36,7 @@ struct execmsg {
 	int num_env_entries;
 	int single_output;
 	int need_namespacing;
+	int run_in_bash;
 };
 
 #define JOB_MAX 64

--- a/src/tup/server/windepfile.c
+++ b/src/tup/server/windepfile.c
@@ -233,7 +233,7 @@ static int create_process(struct server *s, int dfd, char *cmdline,
 #define SHSTR  "sh -c '"
 #define CMDSTR "CMD.EXE /Q /C "
 int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newenv,
-		struct tup_entry *dtent, int need_namespacing)
+		struct tup_entry *dtent, int need_namespacing, int run_in_bash)
 {
 	int rc = -1;
 	DWORD return_code = 1;
@@ -260,6 +260,7 @@ int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newe
 
 	if(dtent) {}
 	if(need_namespacing) {}
+	if(run_in_bash) {}
 
 	if(initialize_depfile(s, depfile, &h) < 0) {
 		fprintf(stderr, "Error starting update server.\n");

--- a/src/tup/server/windepfile.c
+++ b/src/tup/server/windepfile.c
@@ -233,7 +233,7 @@ static int create_process(struct server *s, int dfd, char *cmdline,
 #define SHSTR  "sh -c '"
 #define CMDSTR "CMD.EXE /Q /C "
 int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newenv,
-		struct tup_entry *dtent, int need_namespacing, int run_in_bash)
+		struct tup_entry *dtent, struct exec_flags flags)
 {
 	int rc = -1;
 	DWORD return_code = 1;
@@ -259,8 +259,7 @@ int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newe
 	int need_cmd = 0;
 
 	if(dtent) {}
-	if(need_namespacing) {}
-	if(run_in_bash) {}
+	(void)(flags); // unused on windows
 
 	if(initialize_depfile(s, depfile, &h) < 0) {
 		fprintf(stderr, "Error starting update server.\n");

--- a/src/tup/updater.c
+++ b/src/tup/updater.c
@@ -2547,9 +2547,8 @@ static int update(struct node *n)
 	struct tupid_entries group_sticky_root = {NULL};
 	struct tup_env newenv;
 	struct timespan ts;
-	int need_namespacing = 0;
 	int compare_outputs = 0;
-	int run_in_bash = 0;
+	struct exec_flags flags = {0, 0};
 	int use_server = 0;
 	struct tupid_entries used_groups_root = {NULL};
 
@@ -2559,13 +2558,13 @@ static int update(struct node *n)
 		while(*name && *name != ' ' && *name != '^') {
 			switch(*name) {
 				case 'c':
-					need_namespacing = 1;
+					flags.need_namespacing = 1;
 					break;
 				case 'o':
 					compare_outputs = 1;
 					break;
 				case 'b':
-					run_in_bash = 1;
+					flags.run_in_bash = 1;
 					break;
 				default:
 					pthread_mutex_lock(&display_mutex);
@@ -2626,7 +2625,7 @@ static int update(struct node *n)
 		rc = do_ln(&s, n->tent->parent, dfd, cmd + 8);
 		pthread_mutex_unlock(&db_mutex);
 	} else {
-		rc = server_exec(&s, dfd, cmd, &newenv, n->tent->parent, need_namespacing, run_in_bash);
+		rc = server_exec(&s, dfd, cmd, &newenv, n->tent->parent, flags);
 		use_server = 1;
 	}
 	if(rc < 0) {

--- a/src/tup/updater.c
+++ b/src/tup/updater.c
@@ -2549,6 +2549,7 @@ static int update(struct node *n)
 	struct timespan ts;
 	int need_namespacing = 0;
 	int compare_outputs = 0;
+	int run_in_bash = 0;
 	int use_server = 0;
 	struct tupid_entries used_groups_root = {NULL};
 
@@ -2562,6 +2563,9 @@ static int update(struct node *n)
 					break;
 				case 'o':
 					compare_outputs = 1;
+					break;
+				case 'b':
+					run_in_bash = 1;
 					break;
 				default:
 					pthread_mutex_lock(&display_mutex);
@@ -2622,7 +2626,7 @@ static int update(struct node *n)
 		rc = do_ln(&s, n->tent->parent, dfd, cmd + 8);
 		pthread_mutex_unlock(&db_mutex);
 	} else {
-		rc = server_exec(&s, dfd, cmd, &newenv, n->tent->parent, need_namespacing);
+		rc = server_exec(&s, dfd, cmd, &newenv, n->tent->parent, need_namespacing, run_in_bash);
 		use_server = 1;
 	}
 	if(rc < 0) {

--- a/test/t9500-bash-shell-test.sh
+++ b/test/t9500-bash-shell-test.sh
@@ -1,0 +1,38 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# Copyright (C) 2011-2016  Mike Shal <marfey@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Test that $BASH is set in bash
+. ./tup.sh
+check_bash
+check_no_windows
+
+cat > Tupfile << HERE
+: |> ^b^ echo \$BASH > %o |> bash.txt
+HERE
+tup touch Tupfile
+update
+
+check_exist bash.txt
+
+# Check that bash is not "empty" i.e. $BASH was defined
+if echo | cmp - bash.txt > /dev/null 2>&1; then
+	echo "[31m*** \$BASH was undefined in bash :-rule.[0m"
+    exit 1
+fi
+
+eotup

--- a/test/t9501-bash-pipefail-test.sh
+++ b/test/t9501-bash-pipefail-test.sh
@@ -1,0 +1,38 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# Copyright (C) 2011-2016  Mike Shal <marfey@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Test that a tuprule with a pipefail fails in bash
+. ./tup.sh
+check_bash
+check_no_windows
+
+# Test that normal pipefail passes successfully
+cat > Tupfile << HERE
+: |> false | true |>
+HERE
+tup touch Tupfile
+update
+
+# Test that if fails in a bash rule
+cat > Tupfile << HERE
+: |> ^b^ false | true |>
+HERE
+tup touch Tupfile
+update_fail_msg 'Command ID=[0-9]* failed with return value 1'
+
+eotup

--- a/test/tup.sh
+++ b/test/tup.sh
@@ -637,6 +637,17 @@ HERE
 	rm tmpversioncheck.py
 }
 
+check_bash()
+{
+    if [ ! -e /usr/bin/env ]; then
+		echo "[33m/usr/bin/env not found - skipping test.[0m"
+		eotup
+    elif ! which bash > /dev/null 2>&1; then
+		echo "[33mNo bash found - skipping test.[0m"
+		eotup
+    fi
+}
+
 single_threaded()
 {
 	(echo "[updater]"; echo "num_jobs=1") >> .tup/options

--- a/tup.1
+++ b/tup.1
@@ -418,6 +418,9 @@ In a command string that uses the ^\ TEXT^ sequence, flag characters can be plac
 In the foo.c case, the command requires namespaces (or suid) and will display "CC foo.c". In the bar.c case, the command requires namespaces (or suid) and the "gcc --coverage bar.c -o bar" string is displayed. These are the supported flag characters:
 .RS
 .TP
+.B b
+The 'b' flag causes the command to be run via "/usr/bin/env bash -e -o pipefail -c <command>" instead of the default "/bin/sh -e -c <command>". In addition to allowing bash extensions in the :-rule, "-o pipefail" dictates that "the return value of a pipeline is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands in the pipeline exit successfully."
+.TP
 .B c
 The 'c' flag causes the command to fail if tup does not support user namespaces (on Linux) or is not suid root. In these cases, tup runs in a degraded mode where the fake working directories are visible in the sub-processes, and some dependencies may be missed. If these degraded behaviors will break your a particular command in your build, add the 'c' flag so that users know they need to add the suid bit or upgrade their kernel. This flag is ignored on Windows.
 .TP


### PR DESCRIPTION
I attempted to sign the CLA, but CLAHub wouldn't process the request. I'm not entirely sure what due diligence is due on my part to verify the patch is up to standard. It compiles with werror and all tests pass of my x64 Ubuntu 15.10 machine, but it may not compile on windows / other environments. I also ran ./bench.sh NUM=10000, but got a lot of "tup: Unable to find tupid for 'link_exists'" messages. I'm not sure what those mean, but ignoring them, the differences between the branches is minimal.

Results

origin/master$ ./bench.sh NUM=10000
 Bench[b00-init.sh]:	0.01s 28k
 Bench[b10-create.sh]:	0.06s 452k
 Bench[b11-link.sh]:	 0.69s 1688k
 Bench[b12-update.sh]:	66.64s 6188k
 Bench[b13-reupdate.sh]:	145.66s 6192k
 Bench[b14-delete.sh]:	86.07s 6192k
 Bench[b20-create-select.sh]:	0.11s 452k
 Bench[b21-link-select.sh]:	45.61s 1688k
 ----------------------------------
 Summary:		298.55s 22880k

master$ ./bench.sh NUM=10000
 Bench[b00-init.sh]:	0.01s 28k
 Bench[b10-create.sh]:	0.06s 452k
 Bench[b11-link.sh]:	 0.70s 1688k
 Bench[b12-update.sh]:	75.56s 6188k
 Bench[b13-reupdate.sh]:	149.95s 6192k
 Bench[b14-delete.sh]:	69.69s 6188k
 Bench[b20-create-select.sh]:	0.09s 452k
 Bench[b21-link-select.sh]:	38.60s 1688k
 ----------------------------------
 Summary:		295.36s 22876k

In addition, I may not have updated everything you would want, e.g. a version number.

Finally, I used bit fields to pack more flags into a single word (compiler dependent), but I didn't see this used anywhere else in the codebase so maybe it's not stylistically preferred.