### PR TITLE
Add exec_flags struct to server.h

### DIFF
--- a/src/tup/server.h
+++ b/src/tup/server.h
@@ -56,6 +56,11 @@ struct parser_server {
 	pthread_mutex_t lock;
 };
 
+struct exec_flags {
+	int need_namespacing : 1;
+	int run_in_bash : 1;
+};
+
 enum server_mode {
 	SERVER_CONFIG_MODE,
 	SERVER_PARSER_MODE,
@@ -67,7 +72,7 @@ int server_post_exit(void);
 int server_init(enum server_mode mode);
 int server_quit(void);
 int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newenv,
-		struct tup_entry *dtent, int need_namespacing, int run_in_bash);
+		struct tup_entry *dtent, struct exec_flags flags);
 int server_postexec(struct server *s);
 int server_is_dead(void);
 int server_config_start(struct server *s);

--- a/src/tup/server/fuse_server.c
+++ b/src/tup/server/fuse_server.c
@@ -435,8 +435,7 @@ static int finfo_wait_open_count(struct server *s)
 }
 
 static int exec_internal(struct server *s, const char *cmd, struct tup_env *newenv,
-			 struct tup_entry *dtent, int single_output, int need_namespacing,
-			 int run_in_bash)
+			 struct tup_entry *dtent, int single_output, struct exec_flags flags)
 {
 	int status;
 	char buf[64];
@@ -448,8 +447,7 @@ static int exec_internal(struct server *s, const char *cmd, struct tup_env *newe
 	memset(&em, 0, sizeof(em));
 	em.sid = s->id;
 	em.single_output = single_output;
-	em.need_namespacing = need_namespacing;
-	em.run_in_bash = run_in_bash;
+	em.flags = flags;
 	em.envlen = newenv->block_size;
 	em.num_env_entries = newenv->num_entries;
 	em.joblen = snprintf(job, sizeof(job), TUP_MNT "/" TUP_JOB "%i", s->id) + 1;
@@ -536,7 +534,7 @@ static int exec_internal(struct server *s, const char *cmd, struct tup_env *newe
 }
 
 int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newenv,
-		struct tup_entry *dtent, int need_namespacing, int run_in_bash)
+		struct tup_entry *dtent, struct exec_flags flags)
 {
 	int rc;
 
@@ -545,7 +543,7 @@ int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newe
 	if(tup_fuse_add_group(s->id, &s->finfo) < 0)
 		return -1;
 
-	rc = exec_internal(s, cmd, newenv, dtent, 1, need_namespacing, run_in_bash);
+	rc = exec_internal(s, cmd, newenv, dtent, 1, flags);
 
 	if(tup_fuse_rm_group(&s->finfo) < 0)
 		return -1;
@@ -577,8 +575,9 @@ int server_run_script(FILE *f, tupid_t tupid, const char *cmdline,
 	s.signalled = 0;
 	s.error_mutex = NULL;
 	tent = tup_entry_get(tupid);
+	struct exec_flags flags = {0};
 	init_file_info(&s.finfo, tup_entry_variant(tent)->variant_dir);
-	if(exec_internal(&s, cmdline, &te, tent, 0, 0, 0) < 0)
+	if(exec_internal(&s, cmdline, &te, tent, 0, flags) < 0)
 		return -1;
 	environ_free(&te);
 

--- a/src/tup/server/master_fork.c
+++ b/src/tup/server/master_fork.c
@@ -20,7 +20,6 @@
 
 #define _GNU_SOURCE
 #include "master_fork.h"
-#include "tup/server.h"
 #include "tup/db_types.h"
 #include "tup/tupid_tree.h"
 #include "tup/container.h"
@@ -210,7 +209,7 @@ int server_pre_init(void)
 int server_post_exit(void)
 {
 	int status;
-	struct execmsg em = {-1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+	struct execmsg em = {-1, 0, 0, 0, 0, 0, 0, 0, {0}};
 
 	if(!inited)
 		return 0;
@@ -614,7 +613,7 @@ static int master_fork_loop(void)
 		snprintf(waiter->dev, sizeof(waiter->dev), "%s/dev", job);
 		snprintf(waiter->proc, sizeof(waiter->proc), "%s/proc", job);
 #ifdef __APPLE__
-		if(full_deps || (em.need_namespacing && privileged)) {
+		if(full_deps || (em.flags.need_namespacing && privileged)) {
 			waiter->umount_dev = 1;
 		}
 #endif
@@ -662,10 +661,10 @@ static int master_fork_loop(void)
 			curp++;
 			*curp = NULL;
 
-			if(setup_subprocess(em.sid, job, dir, waiter->dev, waiter->proc, em.single_output, em.need_namespacing) < 0)
+			if(setup_subprocess(em.sid, job, dir, waiter->dev, waiter->proc, em.single_output, em.flags.need_namespacing) < 0)
 				exit(1);
 
-			if(em.run_in_bash) {
+			if(em.flags.run_in_bash) {
 				execle("/usr/bin/env", "/usr/bin/env", "bash", "-e", "-o", "pipefail", "-c", cmd, NULL, envp);
 			} else {
 				execle("/bin/sh", "/bin/sh", "-e", "-c", cmd, NULL, envp);

--- a/src/tup/server/master_fork.h
+++ b/src/tup/server/master_fork.h
@@ -21,6 +21,7 @@
 #ifndef tup_master_fork_h
 #define tup_master_fork_h
 
+#include "tup/server.h"
 #include "tup/compat.h"
 #include "tup/tupid.h"
 
@@ -35,8 +36,7 @@ struct execmsg {
 	int vardictlen;
 	int num_env_entries;
 	int single_output;
-	int need_namespacing;
-	int run_in_bash;
+	struct exec_flags flags;
 };
 
 #define JOB_MAX 64

--- a/src/tup/server/windepfile.c
+++ b/src/tup/server/windepfile.c
@@ -234,7 +234,7 @@ static int create_process(struct server *s, int dfd, char *cmdline,
 #define BASHSTR "bash -e -o pipefail -c '"
 #define CMDSTR "CMD.EXE /Q /C "
 int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newenv,
-		struct tup_entry *dtent, int need_namespacing, int run_in_bash)
+		struct tup_entry *dtent, struct exec_flags flags)
 {
 	int rc = -1;
 	DWORD return_code = 1;
@@ -259,7 +259,6 @@ int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newe
 	int need_cmd = 0;
 
 	if(dtent) {}
-	if(need_namespacing) {}
 
 	if(initialize_depfile(s, depfile, &h) < 0) {
 		fprintf(stderr, "Error starting update server.\n");
@@ -291,7 +290,7 @@ int server_exec(struct server *s, int dfd, const char *cmd, struct tup_env *newe
 			strchr(cmd, '|') != NULL ||
 			strchr(cmd, '>') != NULL ||
 			strchr(cmd, '<') != NULL;
-		if(run_in_bash) {
+		if(need_sh && flags.run_in_bash) {
 			strcat(cmdline, BASHSTR);
 		} else if(need_sh) {
 			strcat(cmdline, SHSTR);

--- a/src/tup/updater.c
+++ b/src/tup/updater.c
@@ -2547,9 +2547,8 @@ static int update(struct node *n)
 	struct tupid_entries group_sticky_root = {NULL};
 	struct tup_env newenv;
 	struct timespan ts;
-	int need_namespacing = 0;
 	int compare_outputs = 0;
-	int run_in_bash = 0;
+	struct exec_flags flags = {0};
 	int use_server = 0;
 	struct tupid_entries used_groups_root = {NULL};
 
@@ -2559,13 +2558,13 @@ static int update(struct node *n)
 		while(*name && *name != ' ' && *name != '^') {
 			switch(*name) {
 				case 'c':
-					need_namespacing = 1;
+					flags.need_namespacing = 1;
 					break;
 				case 'o':
 					compare_outputs = 1;
 					break;
 				case 'b':
-					run_in_bash = 1;
+					flags.run_in_bash = 1;
 					break;
 				default:
 					pthread_mutex_lock(&display_mutex);
@@ -2626,7 +2625,7 @@ static int update(struct node *n)
 		rc = do_ln(&s, n->tent->parent, dfd, cmd + 8);
 		pthread_mutex_unlock(&db_mutex);
 	} else {
-		rc = server_exec(&s, dfd, cmd, &newenv, n->tent->parent, need_namespacing, run_in_bash);
+		rc = server_exec(&s, dfd, cmd, &newenv, n->tent->parent, flags);
 		use_server = 1;
 	}
 	if(rc < 0) {


### PR DESCRIPTION
Originally this wasn't merged due to valgrind errors. This change isn't important as it's early optimization, but I thought I might as well try and replicate the issues and see what was causing them. 

I tried:
```
$ TUP_VALGRIND=1 ./test.sh t4181*

 --- Run t4181-bash-shell-test.sh --- 
.tup repository initialized.
[ tup ] [0.115s] Scanning filesystem...
[ tup ] [0.223s] Reading in new environment variables...
[ tup ] [0.283s] Parsing Tupfiles...
 1) [0.185s] .
 [ ] 100%
[ tup ] [0.660s] No files to delete.                                                      
[ tup ] [0.681s] Generating .gitignore files...
[ tup ] [0.690s] Executing Commands...
 1) [0.130s] echo $BASH > bash.txt                                                        
 [ ] 100%
[ tup ] [1.077s] Updated.                                                                 
==3907== FILE DESCRIPTORS: 0 open at exit.
==3907== 
==3906== FILE DESCRIPTORS: 0 open at exit.
==3906== 
```

Which seems to indicate clean output for me. Is this a platform issue? Are there other settings for valgrind that I don't have set?

I'm using ubuntu 15.10 with the following maybe useful things
```
$ ./tup --version
tup v0.7.4-11-g4d18a5d

$ valgrind --version
valgrind-3.11.0

$ gcc --version
gcc (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010

$ cat tup.config 
CONFIG_TUP_WERROR=y
```