### PR TITLE
add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: required
+dist: trusty
+
+git:
+  depth: 1000  # if last tag is older than 50 commits
+
+language: c
+
+compiler:
+  - clang
+  - gcc
+
+addons:
+  apt:
+    packages:
+      - libfuse-dev
+      - pkg-config
+      - fuse
+
+before_install:
+  - sudo modprobe fuse
+  - sudo chmod 666 /dev/fuse
+  - sudo chown root:$USER /etc/fuse.conf
+
+script:
+  - ./bootstrap.sh
+  - cd test && ./test.sh


### PR DESCRIPTION
Add travis support for testing tup here, so that any pull request get compiled (with both clang and gcc) and tested, in a clean environment.

For the travis' hacker, we need `trusty` because we want fuse support, we require `sudo` to have use it. Also we need  to set the `git depth` to allow old tags to be used by `git describe`