### PR TITLE
Add spaces

### DIFF
--- a/test/t2198-tupfile-spaces.sh
+++ b/test/t2198-tupfile-spaces.sh
@@ -1,0 +1,30 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# Copyright (C) 2008-2016  Mike Shal <marfey@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Check a rule with quotes in a Tupfile
+
+. ./tup.sh
+cat > Tupfile << HERE
+: |> touch "a b" |> "a b"
+: "a b" |> touch "c d" |> "c d"
+HERE
+update
+tup_object_exist . "a b"
+tup_object_exist . "c d"
+
+eotup

--- a/test/t2199-tupfile-escaped.sh
+++ b/test/t2199-tupfile-escaped.sh
@@ -1,0 +1,30 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# Copyright (C) 2008-2016  Mike Shal <marfey@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Check a rule with escaped path in a Tupfile
+
+. ./tup.sh
+cat > Tupfile << HERE
+: |> touch "a b" |> a\ b
+: a\ b |> touch "c d" |> c\ d
+HERE
+update
+tup_object_exist . "a b"
+tup_object_exist . "c d"
+
+eotup

--- a/test/t2200-tupfile-space-escaped.sh
+++ b/test/t2200-tupfile-space-escaped.sh
@@ -1,0 +1,29 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# Copyright (C) 2008-2016  Mike Shal <marfey@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Check a rule with escaped quote in a Tupfile
+
+. ./tup.sh
+cat > Tupfile << HERE
+: |> touch 'a"' ' b' |> a\" \ b
+HERE
+update
+tup_object_exist . 'a"'
+tup_object_exist . ' b'
+
+eotup


### PR DESCRIPTION
Add support for spaces in file names. Simulate an sh style parsing.

We can now write
```tup
: a\ b |> touch "c d" |> "c d"
```
meaning that this rule depend on a file "a b" and generate a file "c d".

Do no support single quote, but that's two lines to write; maybe, we may want to extend it to also support it, but not interpolating flags and stuff.