### PR TITLE
Add arm64 support

### DIFF
--- a/src/tup/platform.c
+++ b/src/tup/platform.c
@@ -54,6 +54,8 @@ const char *tup_arch = "alpha";
 const char *tup_arch = "sparc";
 #elif __arm__
 const char *tup_arch = "arm";
+#elif __aarch64__
+const char *tup_arch = "arm64";
 #else
 #error Unsupported cpu architecture. Please add support in tup/platform.c
 #endif

--- a/tup.1
+++ b/tup.1
@@ -684,7 +684,7 @@ In this case, the @-variable "FOO" is explicitly set to "n".
 TUP_PLATFORM is a special @-variable. If CONFIG_TUP_PLATFORM is not set in the tup.config file, it has a default value according to the platform that tup itself was compiled in. Currently the default value is one of "linux", "solaris", "macosx", "win32", or "freebsd".
 .TP
 .B @(TUP_ARCH)
-TUP_ARCH is another special @-variable. If CONFIG_TUP_ARCH is not set in the tup.config file, it has a default value according to the processor architecture that tup itself was compiled in. Currently the default value is one of "i386", "x86_64", "powerpc", "powerpc64", "ia64", "alpha", "sparc" or "arm".
+TUP_ARCH is another special @-variable. If CONFIG_TUP_ARCH is not set in the tup.config file, it has a default value according to the processor architecture that tup itself was compiled in. Currently the default value is one of "i386", "x86_64", "powerpc", "powerpc64", "ia64", "alpha", "sparc", "arm64", or "arm".
 
 .SH "VARIANTS"
 Tup supports variants, which allow you to build your project multiple times with different configurations. Perhaps the most common case is to build a release and a debug configuration with different compiler flags, though any number of variants can be used to support whatever configurations you like. Each variant is built in its own directory distinct from each other and from the source tree. When building with variants, the in-tree build is disabled. To create a variant, make a new directory at the top of the tup hierarchy and create a "tup.config" file there. For example:


### PR DESCRIPTION
With this patch, tup builds and runs correctly on my linux/arm64 board.

(P.S. I'm happy to call it "aarch64" instead of "arm64" if you believe that is the dominant convention, but I've seen it done both ways.)