### PR TITLE
remove shell glob from gitignore

### DIFF
--- a/test/t9006-gitignore-without-glob.sh
+++ b/test/t9006-gitignore-without-glob.sh
@@ -1,0 +1,38 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# Copyright (C) 2009-2016  Mike Shal <marfey@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Try to use the .gitignore directive
+
+. ./tup.sh
+cat > Tuprules.tup << HERE
+.gitignore
+HERE
+
+cat > Tupfile << HERE
+: foreach *.c |> gcc -c %f -o %o |> %B.o
+: *.o |> gcc %f -o %o |> [asd]
+include_rules
+HERE
+echo 'int main(void) {return 0;}' > foo.c
+
+tup touch foo.c bar.c Tupfile Tuprules.tup
+update
+
+gitignore_good '/\\\[asd\\\]' .gitignore
+
+eotup


### PR DESCRIPTION
When tup generate file with name like `my_file_[abc]`, it writes in the gitignore `/my_file_[abc]`, which is taken as a shell glob by git, which will match `my_file_a` (or `my_file_b` or `my_file_c`), but not the generated file.

By escaping these, we can avoid the globing and thus git will ignore it.

I only cared about the `[` and `]` case, but it's easy to add other cases (such as `*`), I can do it in this PR if wanted (just give me what to escape).