### PR TITLE
omit hidden directory entirely

### DIFF
--- a/src/tup/path.c
+++ b/src/tup/path.c
@@ -43,6 +43,9 @@ static int watch_path_internal(tupid_t dt, const char *file,
 	struct flist f = FLIST_INITIALIZER;
 	struct stat buf;
 
+	if(file[0] == '.' && file[1])
+		return 0;
+
 	if(lstat(file, &buf) != 0) {
 		if(errno == ENOENT) {
 			/* The file may have been created and then removed before


### PR DESCRIPTION
I don't see any need to look into hidden directory (and therefore track its content).

According to man: «Tup doesn't track files that have a hidden path component (those that begin with a '.' character)». Is there any reason to treat directories the other way?