### PR TITLE
Make tup's build more configurable

### DIFF
--- a/Tuprules.tup
+++ b/Tuprules.tup
@@ -12,23 +12,13 @@ else
 CC = gcc
 endif
 
-ifeq (@(TUP_DEBUG),y)
-CFLAGS += -g
+CFLAGS += -D_FILE_OFFSET_BITS=64
+CFLAGS += -I$(TUP_CWD)/src
+ifdef CFLAGS
+CFLAGS += @(CFLAGS)
 else
-CFLAGS += -Os
-endif
-
-ifdef AR
-AR = @(AR)
-else
-AR = ar
-endif
-
 CFLAGS += -W
 CFLAGS += -Wall
-ifeq (@(TUP_WERROR),y)
-CFLAGS += -Werror
-endif
 CFLAGS += -Wbad-function-cast
 CFLAGS += -Wcast-align
 CFLAGS += -Wcast-qual
@@ -42,12 +32,13 @@ CFLAGS += -Wstrict-prototypes
 CFLAGS += -Wwrite-strings
 CFLAGS += -Wswitch-enum
 CFLAGS += -fno-common
-CFLAGS += -D_FILE_OFFSET_BITS=64
-CFLAGS += -I$(TUP_CWD)/src
+CFLAGS += -O2
+endif
 
-ifeq (@(TUP_32_BIT),y)
-CFLAGS += -m32
-LDFLAGS += -m32
+ifdef AR
+AR = @(AR)
+else
+AR = ar
 endif
 
 export PKG_CONFIG_PATH

--- a/Tuprules.tup
+++ b/Tuprules.tup
@@ -35,6 +35,10 @@ CFLAGS += -fno-common
 CFLAGS += -O2
 endif
 
+ifdef LDFLAGS
+LDFLAGS += @(LDFLAGS)
+endif
+
 ifdef AR
 AR = @(AR)
 else

--- a/configs/gcc-dev.config
+++ b/configs/gcc-dev.config
@@ -1,0 +1,1 @@
+CONFIG_CFLAGS=-W -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wchar-subscripts -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wwrite-strings -Wswitch-enum -Werror -fno-common -g -Og

--- a/configs/gcc-release.config
+++ b/configs/gcc-release.config
@@ -1,0 +1,1 @@
+CONFIG_CFLAGS=-Wall -fno-common -O2


### PR DESCRIPTION
The goal of this pull request is to make it easier to change the flags with which tup itself is built. Previously, doing that required tweaking the Tupfiles themselves; with these commits, a level of configurability is supported via tup.config, which the user can provide. This way is better not only because it separates the _what to build_ from the _how to do it_, but also because Kconfig syntax poses a lower entry level for those wanting to build tup.

Being able to change build flags is desirable for several reasons. It's also required when targetting various platforms, and it frees us from the burden of providing the right flags for every situation.

In case no configuration is specified, the previous flags are used. I have tested building with no configuration on Windows, and it works.

To help users and contributors, a couple config templates are supplied.