### PR TITLE
Make tup_version a variable

### DIFF
--- a/src/tup/db.c
+++ b/src/tup/db.c
@@ -636,7 +636,7 @@ static int version_check(void)
 	}
 
 	if(version > DB_VERSION) {
-		fprintf(stderr, "tup error: database is version %i, but this version of tup (%s) can only handle up to %i.\n", version, tup_version(), DB_VERSION);
+		fprintf(stderr, "tup error: database is version %i, but this version of tup (%s) can only handle up to %i.\n", version, tup_version, DB_VERSION);
 		return -1;
 	}
 	if(version != DB_VERSION) {

--- a/src/tup/init.c
+++ b/src/tup/init.c
@@ -43,7 +43,7 @@
 int tup_init(void)
 {
 	if(find_tup_dir() != 0) {
-		fprintf(stderr, "tup %s usage: tup [args]\n", tup_version());
+		fprintf(stderr, "tup %s usage: tup [args]\n", tup_version);
 		fprintf(stderr, "For information on Tupfiles and other commands, see the tup(1) man page.\n");
 		fprintf(stderr, "No .tup directory found. Either create a Tupfile.ini file at the top of your project, or manually run 'tup init' there.\n");
 		return -1;

--- a/src/tup/tup/main.c
+++ b/src/tup/tup/main.c
@@ -1029,5 +1029,5 @@ static int ghost_check(void)
 
 static void version(void)
 {
-	printf("tup %s\n", tup_version());
+	printf("tup %s\n", tup_version);
 }

--- a/src/tup/version.h
+++ b/src/tup/version.h
@@ -21,7 +21,7 @@
 #ifndef tup_version_h
 #define tup_version_h
 
-/* This function is defined by an automatically generated file */
-const char *tup_version(void);
+/* This constant is defined by an automatically generated file */
+extern const char *tup_version;
 
 #endif

--- a/src/tup/version/Tupfile
+++ b/src/tup/version/Tupfile
@@ -1,6 +1,6 @@
 include_rules
 ifneq (@(TUP_PLATFORM),win32)
-: |> version=`git describe` ; (echo '#include "tup/version.h"'; echo "const char *tup_version(void) {return \"$version\";}") > %o |> version.c
+: |> version=`git describe` ; (echo '#include "tup/version.h"'; echo "const char *tup_version = \"$version\";") > %o |> version.c
 else
 : |> produce_version.bat >%o |> version.c
 endif

--- a/src/tup/version/produce_version.bat
+++ b/src/tup/version/produce_version.bat
@@ -1,6 +1,6 @@
 echo #include ^"tup/version.h^"
-echo|set /p="const char *tup_version(void) {return ""
+echo|set /p="const char *tup_version = ""
 FOR /F "tokens=* USEBACKQ" %%F IN (`git describe`) DO (
 SET var=%%F
 )
-echo %var%^";}
+echo %var%^";


### PR DESCRIPTION
Since the version string is meant to be a constant, it's represented better by a variable than by a function. Just some petty nitpicking, otherwise.