### PR TITLE
fix readlink test by forcing resolution

### DIFF
--- a/test/t4131-proc-self-exe.sh
+++ b/test/t4131-proc-self-exe.sh
@@ -28,14 +28,14 @@ check_tup_suid
 set_full_deps
 
 cat > Tupfile << HERE
-: |> readlink /proc/self/exe > %o |> file.txt
+: |> readlink -e /proc/self/exe > %o |> file.txt
 HERE
 tup touch Tupfile
 update
 
 rlink=`which readlink`
 if test -h $rlink; then
-	text=`readlink $rlink`
+	text=`readlink -e $rlink`
 else
 	text=$rlink
 fi


### PR DESCRIPTION
```
 --- Run t4131-proc-self-exe.sh ---
.tup repository initialized.
[ tup ] [0.001s] Scanning filesystem...
[ tup ] [0.002s] Reading in new environment variables...
[ tup ] [0.003s] Parsing Tupfiles...
 1) [0.003s] .
[ tup ] [0.009s] No files to delete.
[ tup ] [0.009s] Generating .gitignore files...
[ tup ] [0.010s] Executing Commands...
 1) [0.031s] readlink /proc/self/exe > file.txt
[ tup ] [0.042s] Updated.
1c1
< ../../bin/readlink
---
> /bin/readlink
 *** t4131-proc-self-exe.sh failed
```

So, to ensure to correctly resolve the symlink, we need to resolve recursively the path.