### PR TITLE
Add tests for moving nodes in fuse_fs

### DIFF
--- a/test/t4188-mv-file.sh
+++ b/test/t4188-mv-file.sh
@@ -1,0 +1,29 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# Copyright (C) 2011-2017  Mike Shal <marfey@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# make sure that we can move files around.
+
+. ./tup.sh
+
+cat > Tupfile << HERE
+: |> touch a && mv a b |> b
+HERE
+tup touch Tupfile
+update
+
+eotup

--- a/test/t4189-mv-dir.sh
+++ b/test/t4189-mv-dir.sh
@@ -1,0 +1,31 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# Copyright (C) 2011-2017  Mike Shal <marfey@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Make sure directories can be moved around.
+
+. ./tup.sh
+
+# TODO: Ideally, tup would handle generated directories.
+# for now, just delete the directory, and create a dummy file.
+cat > Tupfile << HERE
+: |> mkdir a && mv a b && rmdir b && touch c |> c
+HERE
+tup touch Tupfile
+update
+
+eotup


### PR DESCRIPTION
I was surprised to see that a simple `mkdir a && mv a b` does not work in fuse_fs.
The error is that node 'a' does not exist.
**The second test does not pass ATM, it just outlines the bug**

When moving files around, fuse_fs does not look in the list of temporary dirs.
This occurred while I was investigating the possibility to support generated directories.
It shows that directories are handled separately from generated files, increasing the required work to support generated directories.

Leaving generated directories aside, `mkdir a && mv a b` looks like something we would want to support anyway.