### PR TITLE
fix tup on musl (fixes #323)

### DIFF
--- a/src/tup/server/fuse_fs.c
+++ b/src/tup/server/fuse_fs.c
@@ -39,13 +39,6 @@
 #include <sys/types.h>
 #include <sys/resource.h>
 
-#if defined(__FreeBSD__)
-/* FreeBSD doessn't support AT_SYMLINK_NOFOLLOW in faccessat() */
-static int access_flags = 0;
-#else
-static int access_flags = AT_SYMLINK_NOFOLLOW;
-#endif
-
 static struct thread_root troot = THREAD_ROOT_INITIALIZER;
 static int server_mode = 0;
 static pid_t ourpgid;
@@ -484,7 +477,7 @@ static int tup_fs_access(const char *path, int mask)
 				 * permissions assigned in mkdir for a temp
 				 * directory.
 				 */
-				if(faccessat(tup_top_fd(), ".", mask, access_flags) < 0)
+				if(faccessat(tup_top_fd(), ".", mask, 0) < 0)
 					rc = -errno;
 				entry_found = 1;
 				break;
@@ -506,11 +499,11 @@ static int tup_fs_access(const char *path, int mask)
 	}
 
 	/* This is preceded by a getattr - no need to handle a read event */
-	res = faccessat(tup_top_fd(), peeled, mask, access_flags);
+	res = faccessat(tup_top_fd(), peeled, mask, 0);
 	if (res == -1 && variant_dir) {
 		const char *stripped = prefix_strip(peeled, variant_dir);
 		if(stripped) {
-			res = faccessat(tup_top_fd(), stripped, mask, access_flags);
+			res = faccessat(tup_top_fd(), stripped, mask, 0);
 		}
 	}
 	if (res == -1)

--- a/src/tup/server/master_fork.c
+++ b/src/tup/server/master_fork.c
@@ -195,8 +195,10 @@ int server_pre_init(void)
 		perror("close(msd[0])");
 		return -1;
 	}
+read_rc_again:
 	rc = read(msd[1], &c, 1);
 	if(rc < 0) {
+		if(errno == EINTR) goto read_rc_again;
 		perror("read");
 		return -1;
 	}
@@ -310,6 +312,7 @@ static int read_all_internal(int sd, void *dest, int size, int line)
 	while(bytes_read < size) {
 		rc = read(sd, p + bytes_read, size - bytes_read);
 		if(rc < 0) {
+			if(errno == EINTR) continue;
 			perror("read");
 			fprintf(stderr, "tup error: Unable to read from the master fork socket (read_all called from line %i).\n", line);
 			return -1;


### PR DESCRIPTION
This patch fixes tup on linux systems based on musl libc (#323)

In the master fork server, handle EINTR on read(2) so that the
delivery of SIGCHLD does not cause the parent to exit spuriously.

In the fuse filesystem, stop using AT_SYMLINK_NOFOLLOW in faccessat(2)
It's not portable; glibc has a special wrapper for it [manpage]. 

[manpage]: https://man7.org/linux/man-pages/man2/faccessat.2.html