### PR TITLE
Add the D %-flag for the dirname.

### DIFF
--- a/src/tup/parser.c
+++ b/src/tup/parser.c
@@ -3585,6 +3585,19 @@ static char *tup_printf(struct tupfile *tf, const char *cmd, int cmd_len,
 				estring_append(&e, nle->base, nle->baselen);
 				first = 0;
 			}
+		} else if(*next == 'D') {
+			int first = 1;
+			if(nl->num_entries == 0) {
+				fprintf(tf->f, "tup error: %%D used in rule pattern and no input files were specified.\n");
+				return NULL;
+			}
+			TAILQ_FOREACH(nle, &nl->entries, list) {
+				if(!first) {
+					estring_append(&e, " ", 1);
+				}
+				estring_append(&e, nle->path, nle->dirlen + (nle->path[nle->dirlen] == path_sep() ? 1 : 0));
+				first = 0;
+			}
 		} else if(*next == 'B') {
 			int first = 1;
 			if(nl->num_entries == 0) {

--- a/test/t2209-dirname.sh
+++ b/test/t2209-dirname.sh
@@ -1,0 +1,32 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# Copyright (C) 2016-2018  Mike Shal <marfey@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Test the %D dirname variable in an output.
+
+. ./tup.sh
+cat > Tupfile << HERE
+: foreach a.txt d/b.txt d/d/c.txt |> cp %f %o |> %D%B.tst
+HERE
+mkdir -p d/d
+touch a.txt d/b.txt d/d/c.txt
+update
+tup_object_exist .   a.tst
+tup_object_exist d   b.tst
+tup_object_exist d/d c.tst
+
+eotup

--- a/tup.1
+++ b/tup.1
@@ -442,6 +442,9 @@ The filename from the "inputs" section. This includes the path and extension. Th
 .B %b
 Like %f, but is just the basename of the file. The directory part is stripped off. For example, "src/foo.c" would become "foo.c"
 .TP
+.B %D
+Like %f, but is just the dirname of the file. The basename is stripped off. For example, "src/foo.c" would become "src/"
+.TP
 .B %B
 Like %b, but strips the extension. This is most useful in converting an input file into an output file of the same name but with a different extension, since the output file needs to be in the same directory. For example, "src/foo.c" would become "foo"
 .TP


### PR DESCRIPTION
%D (dirname) is the counterpart of %b (basename)
It is useful for recreating the source directory structure inside the
build directory.