### PR TITLE
only call setpgid if PGID != PID

### DIFF
--- a/src/tup/server/master_fork.c
+++ b/src/tup/server/master_fork.c
@@ -146,7 +146,7 @@ int server_pre_init(void)
 	char c = 0;
 	int rc;
 	full_deps = tup_option_get_flag("updater.full_deps");
-	if(setpgid(0, 0) < 0) {
+	if(getpid() != getpgid(0) && setpgid(0, 0) < 0) {
 		perror("setpgid");
 		fprintf(stderr, "tup error: Unable to set process group for tup's subprocesses.\n");
 		return -1;


### PR DESCRIPTION
This fixes `tup error: Unable to set process group for tup's subprocesses.` which occurs when running tup as a direct build task in Visual Studio Code.

The issue appears to be caused by VSCode calling setsid before invoking the build command. In fact, it can be reproduced by running:
```
$ setsid tup
setpgid: Operation not permitted
tup error: Unable to set process group for tup's subprocesses.
```

According to [setsid(2)](http://man7.org/linux/man-pages/man2/setsid.2.html) in this case the PGID is already equivalent to the PID so "setpgid(0, 0)" is no longer required.
In my tests the proposed change does in fact fix the issue.