### PR TITLE
Add %i, %#b, and %#B flags

### DIFF
--- a/src/tup/parser.c
+++ b/src/tup/parser.c
@@ -3632,6 +3632,22 @@ static char *tup_printf(struct tupfile *tf, const char *cmd, int cmd_len,
 				estring_append(&e, nle->base, nle->extlessbaselen);
 				first = 0;
 			}
+		} else if(*next == 'i') {
+			int first = 1;
+			if(!ooinput_nl) {
+				fprintf(tf->f, "tup error: %%i is only valid in a command string.\n");
+				return NULL;
+			} else if(ooinput_nl->num_entries == 0) {
+				fprintf(tf->f, "tup error: %%i used in rule pattern and no order-only input files were specified.\n");
+				return NULL;
+			}
+			TAILQ_FOREACH(nle, &ooinput_nl->entries, list) {
+				if(!first) {
+					estring_append(&e, " ", 1);
+				}
+				estring_append(&e, nle->path, nle->len);
+				first = 0;
+			}
 		} else if(*next == 'e') {
 			if(!ext) {
 				fprintf(tf->f, "tup error: %%e is only valid with a foreach rule for files that have extensions.\n");
@@ -3779,27 +3795,36 @@ static char *tup_printf(struct tupfile *tf, const char *cmd, int cmd_len,
 				fprintf(tf->f, "tup error: Expected number from 1-99 (base 10) for %%-flag, but got %i\n", num);
 				return NULL;
 			}
-			if(endp[0] == 'f') {
+			if (*endp == '\0') {
+				fprintf(tf->f, "tup error: Unfinished %%%i-flag at the end of the string '%s'\n", num, cmd);
+				return NULL;
+			} else if(strchr("fBb", *endp)) {
 				tmpnl = nl;
-			} else if(endp[0] == 'o') {
+			} else if(*endp == 'o') {
 				tmpnl = onl;
-			} else if(endp[0] == 'i') {
+			} else if(*endp == 'i') {
 				if(!ooinput_nl) {
 					fprintf(tf->f, "tup error: %%%ii is only valid in a command string.\n", num);
 					return NULL;
 				}
 				tmpnl = ooinput_nl;
 			} else {
-				fprintf(tf->f, "tup error: Expected 'f', 'o', or 'i' after number in %%-flag, but got '%c'\n", endp[0]);
+				fprintf(tf->f, "tup error: Expected 'f', 'b', 'B', 'o', or 'i' after number in %%%i-flag, but got '%c'\n", num, *endp);
 				return NULL;
 			}
 			TAILQ_FOREACH(nle, &tmpnl->entries, list) {
 				if(nle->orderid == num) {
-					if(!first) {
-						if(estring_append(&e, " ", 1) < 0)
-							return NULL;
+					if(!first && estring_append(&e, " ", 1) < 0)
+						return NULL;
+					int err;
+					if(*endp == 'B') {
+						err = estring_append(&e, nle->base, nle->extlessbaselen);
+					} else if(*endp == 'b') {
+						err = estring_append(&e, nle->base, nle->baselen);
+					} else {
+						err = estring_append(&e, nle->path, nle->len);
 					}
-					if(estring_append(&e, nle->path, nle->len) < 0)
+					if(err < 0)
 						return NULL;
 					first = 0;
 				} else if(nle->orderid > num) {

--- a/test/t2048-empty-input-percf.sh
+++ b/test/t2048-empty-input-percf.sh
@@ -37,4 +37,10 @@ HERE
 tup touch Tupfile
 parse_fail_msg "%B used in rule pattern and no input files were specified"
 
+cat > Tupfile << HERE
+: |> cat %i > %o |> bar
+HERE
+tup touch Tupfile
+parse_fail_msg "%i used in rule pattern and no order-only input files were specified"
+
 eotup

--- a/test/t2181-perc-number.sh
+++ b/test/t2181-perc-number.sh
@@ -19,14 +19,15 @@
 # Check %1f, %2f, %1o, etc
 
 . ./tup.sh
+
 cat > Tupfile << HERE
-: file1 file2 foo/file3 |> cmd %1f %3f %2o %1o |> out1 out2
+: file1.ext file2.ext foo/file3.ext file4.ext foo/file5.ext |> cmd %1f %3f %2o %1o %4B %5b |> out1 out2
 HERE
-tup touch file1 file2
 tmkdir foo
-tup touch foo/file3
+tup touch file1.ext file2.ext file4.ext
+tup touch foo/file3.ext foo/file5.ext
 parse
 
-tup_object_exist . 'cmd file1 foo/file3 out2 out1'
+tup_object_exist . 'cmd file1.ext foo/file3.ext out2 out1 file4 file5.ext'
 
 eotup

--- a/test/t2184-perc-number3.sh
+++ b/test/t2184-perc-number3.sh
@@ -20,18 +20,20 @@
 
 . ./tup.sh
 cat > Tupfile << HERE
-files += f1
-files += f2
-files += f3
+files += f1.e
+files += f2.e
+files += f3.e
+files += f/f4.e
 libs += l1
 libs += l2
 libs += l3
 libs += l4
-: test1 \$(files) \$(libs) |> cmd T %1f F %2f L %3f O %1o 2 %2o |> \$(empty) out2
+: test1 \$(files) \$(libs) |> cmd T %1f F %2f b %2b B %2B L %3f O %1o 2 %2o |> \$(empty) out2
 HERE
-tup touch test1 f1 f2 f3 l1 l2 l3 l4
+tmkdir f
+tup touch test1 f1.e f2.e f3.e f/f4.e l1 l2 l3 l4
 parse
 
-tup_object_exist . 'cmd T test1 F f1 f2 f3 L l1 l2 l3 l4 O  2 out2'
+tup_object_exist . 'cmd T test1 F f1.e f2.e f3.e f/f4.e b f1.e f2.e f3.e f4.e B f1 f2 f3 f4 L l1 l2 l3 l4 O  2 out2'
 
 eotup

--- a/test/t2210-perci.sh
+++ b/test/t2210-perci.sh
@@ -16,31 +16,18 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-# Try some failure cases in %1f
+# Check %i works for order-only inputs
 
 . ./tup.sh
-tup touch file1 file2
-tmkdir foo
-tup touch foo/file3
 
 cat > Tupfile << HERE
-: file1 file2 foo/file3 |> cmd %0o |> out1 out2
+: |> echo foo > %o |> foo.txt
+: |> echo bar > %o |> bar.txt
+: dat.in | foo.txt bar.txt |> cat %f > %o && echo %i >> %o |> %B.out
 HERE
-parse_fail_msg "Expected number from 1-99"
+echo dat > dat.in
+parse
 
-cat > Tupfile << HERE
-: file1 file2 foo/file3 |> cmd %100o |> out1 out2
-HERE
-parse_fail_msg "Expected number from 1-99"
-
-cat > Tupfile << HERE
-: file1 file2 foo/file3 |> cmd %1d |> out1 out2
-HERE
-parse_fail_msg "Expected.*after number in"
-
-cat > Tupfile << HERE
-: file1 |> cmd %1|> out1
-HERE
-parse_fail_msg "Unfinished %1-flag at the end of the string"
+tup_object_exist . 'cat dat.in > dat.out && echo foo.txt bar.txt >> dat.out'
 
 eotup


### PR DESCRIPTION
%i functions as %#i but without the number, %#[bB] function as %[bB] but with the number.

This was in an effort to improve consistency of %-flags. However, as soon as I got into the code, I realized that the handing of %-flags is very inconsistent and incredibly manually implemented (just like this pr). It's also not well documented. I would submit documentation with the pr, but I'm going to advocate changing behavior of %#-flags in an issue. To this end, I don't want to submit documentation that's then going to change, hopefully before the next official release.

Also fixes the error reporting when the number is at the end of the command string.