### PR TITLE
$CC needs to be saved in tup.config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,7 @@ else
 fi
 LDFLAGS="$LDFLAGS -lm"
 : ${CC:=gcc}
+echo "CONFIG_CC=$CC" >tup.config
 case "$os" in
 	Linux)
 	plat_files="$plat_files ../src/compat/dummy.c"


### PR DESCRIPTION
When building tup, although the build.sh script allows you to override the $CC variable, it doesn't honor this when later running "./build/tup upd" from the ./bootstrap.sh script.

Symptom: when building tup in a rather strict environment with a non-system compiler using the command "CC=/path/to/non-system/cc ./bootstrap.sh", the build fails when it tries to run "gcc" (which is a fake compiler to catch these kinds of errors).

Fix: set CONFIG_CC to the proper C compiler in tup.config.