### PR TITLE
Missing one '.ccache' exclusion?

### DIFF
--- a/src/tup/pel_group.c
+++ b/src/tup/pel_group.c
@@ -45,6 +45,8 @@ int pel_ignored(const char *path, int len)
 		return 1;
 	if(len == 4 && strncmp(path, ".svn", 4) == 0)
 		return 1;
+	if(len == 7 && strncmp(path, ".ccache", 7) == 0)
+		return 1;
 	/* See also fuse_fs.c:is_hidden() */
 	return 0;
 }


### PR DESCRIPTION
Adding that condition, the folder '.ccache' gets excluded as expected.

** It's excluded from 'fuse_fs.c:is_hidden()' but not from 'pel_group.c:pel_ignored()' as it seems it to should.