### PR TITLE
Fix 32-bit Windows builds

### DIFF
--- a/src/dllinject/dllinject.c
+++ b/src/dllinject/dllinject.c
@@ -2115,6 +2115,7 @@ static uint32_t GET_PROC_ADDRESS_32 = 0;
 
 #define BUFSIZE 4096
 
+#ifdef _WIN64
 BOOL get_wow64_addresses(void)
 {
 	DWORD dwRead;
@@ -2197,6 +2198,14 @@ BOOL get_wow64_addresses(void)
 
 	return TRUE;
 }
+#else
+BOOL get_wow64_addresses(void)
+{
+	LOAD_LIBRARY_32 = (uint32_t)LoadLibraryA;
+	GET_PROC_ADDRESS_32 = (uint32_t)GetProcAddress;
+	return TRUE;
+}
+#endif
 
 
 


### PR DESCRIPTION
These two fixes would allow tup to work correctly when built for 32-bit Windows, by setting both `CONFIG_CC` and `CONFIG_CC32` to `i686-w64-mingw32-gcc`.

The recently added memory pools assumed that `(sizeof(void*) & (pool->alignment-1)) == 0`, which might not always be true in a 32-bit environment. Applying the `pool->alignment` to the `mem` pointer fixes the alignment error you'd otherwise get immediately when retrieving the first item from the pool.

For DLL injection, 32-bit builds can reuse the existing WOW64 code path, but just need some minor parametrization to use the regular, non-WOW64-prefixed versions of types, functions, and constants.

----

Another tiny issue would remain with the build process. A 32-bit build would currently build both `tup-dllinject.dll` and an identical `tup-dllinject32.dll`, with `tup-dllinject.dll` imported by `tup.exe` itself and `tup-dllinject32.dll` used for injection. Optimally, we'd build only one of the two, and then need to check for that case somehow.

Detecting a 32-bit build automatically and then only building `tup-dllinject32.dll` might look like this:
```patch
diff --git a/Tupfile b/Tupfile
index 9b4ab820..39b2eaec 100644
--- a/Tupfile
+++ b/Tupfile
@@ -51,12 +51,24 @@ endif
 LDFLAGS += -lm
 LDFLAGS += -lpthread
 else
+ifneq ($(CC),$(CC32))
+is_64_bit = y
+else
+is_64_bit = n
+endif
+
+ifeq ($(is_64_bit),y)
 : src/dllinject/*.o |> !dll -lpsapi |> tup-dllinject.dll
+endif
 : src/dllinject/*.o32 |> !dll32 -lpsapi |> tup-dllinject32.dll
 : src/compat/win32/detect/*.o32 |> !ld32 |> tup32detect$(PROGRAM_SUFFIX)

 srcs += src/compat/win32/*.o
+ifeq ($(is_64_bit),y)
 srcs += tup-dllinject.dll
+else
+srcs += tup-dllinject32.dll
+endif

 LDFLAGS += -Wl,--wrap=open
 LDFLAGS += -Wl,--wrap=close
```
There might be other options though?