### PR TITLE
Allow generate to run scripts

### DIFF
--- a/src/tup/parser.c
+++ b/src/tup/parser.c
@@ -1029,7 +1029,10 @@ int exec_run_script(struct tupfile *tf, const char *cmdline, int lno)
 		if(tent_tree_add_dup(&tf->input_root, tt->tent) < 0)
 			return -1;
 	}
-	rc = server_run_script(tf->f, tf->tent->tnode.tupid, cmdline, &tf->env_root, &rules);
+	if (tf->use_server)
+		rc = server_run_script(tf->f, tf->tent->tnode.tupid, cmdline, &tf->env_root, &rules);
+	else
+		rc = serverless_run_script(tf->f, tf->tent->tnode.tupid, cmdline, &tf->env_root, &rules);
 	if(rc < 0)
 		return -1;
 

--- a/src/tup/server.h
+++ b/src/tup/server.h
@@ -78,6 +78,8 @@ int server_parser_stop(struct parser_server *ps);
 
 int server_run_script(FILE *f, tupid_t tupid, const char *cmdline,
 		      struct tent_entries *env_root, char **rules);
+int serverless_run_script(FILE *f, tupid_t tupid, const char *cmdline,
+		          struct tent_entries *env_root, char **rules);
 int server_symlink(struct server *s, const char *target, int dfd, const char *linkpath);
 
 #endif

--- a/src/tup/server/fuse_server.c
+++ b/src/tup/server/fuse_server.c
@@ -647,13 +647,11 @@ int server_run_script(FILE *f, tupid_t tupid, const char *cmdline,
 int serverless_run_script(FILE *f, tupid_t tupid, const char *cmdline,
 		          struct tent_entries *env_root, char **rules)
 {
-	struct tup_entry *tent;
 	struct tup_env te;
 
 	if(tup_db_get_environ(env_root, NULL, &te) < 0)
 		return -1;
 
-	tent = tup_entry_get(tupid);
 	int exit_status = -1;
 	int ofd = -1, efd = -1;
 	char buf[64];
@@ -985,8 +983,12 @@ int tup_restore_privs(void)
 	return 0;
 }
 
-int serverless_cleanup_func(const char *path, const struct stat *sb,
-		            int typeflag, struct FTW * ftwbuf) {
+static int serverless_cleanup_func(const char *path, const struct stat *sb,
+		                   int typeflag, struct FTW *ftwbuf)
+{
+	if (sb) {}
+	if (ftwbuf) {}
+
 	if(typeflag == FTW_F || typeflag == FTW_DP || typeflag == FTW_SL) {
 		if (remove(path) != 0) {
 			perror("remove(path)");
@@ -1002,7 +1004,8 @@ int serverless_cleanup_func(const char *path, const struct stat *sb,
 	return 0;
 }
 
-int serverless_clean_tmp_dir(void) {
+int serverless_clean_tmp_dir(void)
+{
 	int cleanup_result = nftw(".tup/tmp", serverless_cleanup_func, 2, FTW_DEPTH | FTW_PHYS | FTW_MOUNT);
 
 	if(cleanup_result != 0)

--- a/src/tup/server/fuse_server.c
+++ b/src/tup/server/fuse_server.c
@@ -41,6 +41,8 @@
 #include <errno.h>
 #include <signal.h>
 #include <sys/mount.h>
+#define __USE_XOPEN_EXTENDED 1
+#include <ftw.h>
 #ifdef __linux__
 #include <sys/sysmacros.h>
 #include <grp.h>
@@ -49,6 +51,7 @@
 
 #define TUP_MNT ".tup/mnt"
 
+int serverless_clean_tmp_dir(void);
 static void sighandler(int sig);
 
 static struct sigaction sigact = {
@@ -641,6 +644,184 @@ int server_run_script(FILE *f, tupid_t tupid, const char *cmdline,
 	return -1;
 }
 
+int serverless_run_script(FILE *f, tupid_t tupid, const char *cmdline,
+		          struct tent_entries *env_root, char **rules)
+{
+	struct tup_entry *tent;
+	struct tup_env te;
+
+	if(tup_db_get_environ(env_root, NULL, &te) < 0)
+		return -1;
+
+	tent = tup_entry_get(tupid);
+	int exit_status = -1;
+	int ofd = -1, efd = -1;
+	char buf[64];
+
+	int tmp_dir = mkdir(".tup/tmp", 0700);
+
+	if(tmp_dir != 0) {
+		perror("mkdir .tup/tmp");
+		return -1;
+	}
+
+	pid_t pid = fork();
+
+	if(pid == -1) {
+		perror("fork");
+		goto failure;
+	} else if(pid > 0) {
+		waitpid(pid, &exit_status, 0);
+
+		snprintf(buf, sizeof(buf), ".tup/tmp/output-%lli", tupid);
+		buf[sizeof(buf)-1] = 0;
+		ofd = open(buf, O_RDONLY);
+		if(ofd < 0) {
+			perror(buf);
+			fprintf(stderr, "tup error: Unable to create temporary file for sub-process output.\n");
+			goto failure;
+		}
+		snprintf(buf, sizeof(buf), ".tup/tmp/errors-%lli", tupid);
+		buf[sizeof(buf)-1] = 0;
+		efd = open(buf, O_RDONLY);
+		if(efd < 0) {
+			perror(buf);
+			fprintf(stderr, "tup error: Unable to create temporary file for sub-process errors.\n");
+			goto failure;
+		}
+	} else {
+		snprintf(buf, sizeof(buf), ".tup/tmp/output-%lli", tupid);
+		buf[sizeof(buf)-1] = 0;
+		ofd = creat(buf, 0600);
+		if(ofd < 0) {
+			perror(buf);
+			fprintf(stderr, "tup error: Unable to create temporary file for sub-process output.\n");
+			goto failure;
+		}
+		if(fchown(ofd, getuid(), getgid()) < 0) {
+			perror("fchown");
+			fprintf(stderr, "tup error: Unable to create temporary file for sub-process output.\n");
+			goto failure;
+		}
+
+		snprintf(buf, sizeof(buf), ".tup/tmp/errors-%lli", tupid);
+		buf[sizeof(buf)-1] = 0;
+		efd = creat(buf, 0600);
+		if(efd < 0) {
+			perror(buf);
+			fprintf(stderr, "tup error: Unable to create temporary file for sub-process errors.\n");
+			goto failure;
+		}
+		if(fchown(efd, getuid(), getgid()) < 0) {
+			perror("fchown");
+			fprintf(stderr, "tup error: Unable to create temporary file for sub-process errors.\n");
+			goto failure;
+		}
+
+		if(dup2(ofd, STDOUT_FILENO) < 0) {
+			perror("dup2");
+			fprintf(stderr, "tup error: Unable to dup stdout for the child process.\n");
+			exit(-1);
+		}
+		if(dup2(efd, STDERR_FILENO) < 0) {
+			perror("dup2");
+			fprintf(stderr, "tup error: Unable to dup stderr for the child process.\n");
+			exit(-1);
+		}
+		if(close(ofd) < 0) {
+			perror("close(ofd)");
+			exit(-1);
+		}
+		int subprocess_null_fd = open("/dev/null", O_RDONLY);
+		if(subprocess_null_fd < 0) {
+			perror("/dev/null");
+			fprintf(stderr, "tup error: Unable to open /dev/null for dup'ing stdin\n");
+			exit(-1);
+		}
+		if(dup2(subprocess_null_fd, STDIN_FILENO) < 0) {
+			perror("dup2");
+			fprintf(stderr, "tup error: Unable to dup stdin for child processes.\n");
+			exit(-1);
+		}
+		if(close(subprocess_null_fd) < 0) {
+			perror("close(null_fd)");
+			exit(-1);
+		}
+
+		char **envp;
+		char **curp;
+		char *curenv;
+
+		envp = malloc((te.num_entries + 2) * sizeof(*envp));
+		if(!envp) {
+			perror("malloc");
+			exit(1);
+		}
+		/* Convert from Windows-style environment to
+		 * Linux-style.
+		 */
+		curp = envp;
+		curenv = te.envblock;
+		int i = 0;
+		while(*curenv && i < te.num_entries) {
+			*curp = curenv;
+			curp++;
+			curenv += strlen(curenv) + 1;
+			i++;
+		}
+		*curp = NULL;
+		execle("/bin/sh", "/bin/sh", "-e", "-c", cmdline, NULL, envp);
+	}
+	environ_free(&te);
+
+	if(display_output(efd, 1, cmdline, 1, f) < 0)
+		goto failure;
+	if(close(efd) < 0) {
+		perror("close(efd)");
+		goto failure;
+	}
+
+	int exited = 0;
+	int signalled = 0;
+	int exit_sig = 0;
+
+	if(WIFEXITED(exit_status)) {
+		exited = 1;
+		exit_status = WEXITSTATUS(exit_status);
+	} else if(WIFSIGNALED(exit_status)) {
+		signalled = 1;
+		exit_sig = WTERMSIG(exit_status);
+	} else {
+		fprintf(stderr, "tup error: Expected exit status to be WIFEXITED or WIFSIGNALED. Got: %i\n", exit_status);
+		goto failure;
+	}
+
+	if(exited) {
+		if(exit_status == 0) {
+			struct buf b;
+			if(fslurp_null(ofd, &b) < 0)
+				return -1;
+			if(close(ofd) < 0) {
+				perror("close(s.output_fd)");
+				return -1;
+			}
+			*rules = b.s;
+			serverless_clean_tmp_dir();
+			return 0;
+		}
+		fprintf(f, "tup error: run-script exited with failure code: %i\n", exit_status);
+	} else {
+		if(signalled) {
+			fprintf(f, "tup error: run-script terminated with signal %i\n", exit_sig);
+		} else {
+			fprintf(f, "tup error: run-script terminated abnormally.\n");
+		}
+	}
+failure:
+	serverless_clean_tmp_dir();
+	return -1;
+}
+
 int server_symlink(struct server *s, const char *target, int dfd, const char *linkpath)
 {
 	if(s) {/* unused */}
@@ -797,6 +978,32 @@ int tup_restore_privs(void)
 		}
 	}
 	return 0;
+}
+
+int serverless_cleanup_func(const char *path, const struct stat *sb,
+		            int typeflag, struct FTW * ftwbuf) {
+	if(typeflag == FTW_F || typeflag == FTW_DP || typeflag == FTW_SL) {
+		if (remove(path) != 0) {
+			perror("remove(path)");
+			return -1;
+		}
+	} else if(typeflag == FTW_D) {
+		fprintf(stderr, "Failed to delete outputs in temporary directory: %s\n", path);
+		return -1;
+	} else {
+		fprintf(stderr, "Unknown file found found when deleting temporary output: %s\n", path);
+		remove(path);
+	}
+	return 0;
+}
+
+int serverless_clean_tmp_dir(void) {
+	int cleanup_result = nftw(".tup/tmp", serverless_cleanup_func, 2, FTW_DEPTH | FTW_PHYS | FTW_MOUNT);
+
+	if(cleanup_result != 0)
+		fprintf(stderr, "Failed to cleanup .tup/mnt, got error code: %i\n", cleanup_result);
+
+	return cleanup_result;
 }
 
 static void sighandler(int sig)

--- a/src/tup/server/fuse_server.c
+++ b/src/tup/server/fuse_server.c
@@ -658,8 +658,13 @@ int serverless_run_script(FILE *f, tupid_t tupid, const char *cmdline,
 	int ofd = -1, efd = -1;
 	char buf[64];
 
-	int tmp_dir = mkdir(".tup/tmp", 0700);
+	int tmp_dir = mkdir(".tup", 0700);
+	if(tmp_dir != 0 && errno != EEXIST) {
+		perror("mkdir .tup");
+		return -1;
+	}
 
+	tmp_dir = mkdir(".tup/tmp", 0700);
 	if(tmp_dir != 0) {
 		perror("mkdir .tup/tmp");
 		return -1;

--- a/test/t2216-generate-shell-script-run.sh
+++ b/test/t2216-generate-shell-script-run.sh
@@ -19,7 +19,8 @@
 . ./tup.sh
 check_no_windows shell
 
-# 'tup generate' with run command requires a tup directory
+# 'tup generate' with run command generates own tup directory
+rm -rf .tup
 
 printf '#! /bin/sh -e\n printf ": |> printf a > output.txt |> output.txt\n"' > script.sh
 chmod +x script.sh

--- a/test/t2216-generate-shell-script-run.sh
+++ b/test/t2216-generate-shell-script-run.sh
@@ -1,0 +1,33 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Try to use a 'run' command in a generate script.
+
+. ./tup.sh
+check_no_windows shell
+
+# 'tup generate' with run command requires a tup directory
+
+printf '#! /bin/sh -e\n printf ": |> printf a > output.txt |> output.txt\n"' > script.sh
+chmod +x script.sh
+cat > Tupfile << HERE
+run ./script.sh
+HERE
+generate $generate_script_name
+./$generate_script_name
+printf a | diff - output.txt
+
+eotup


### PR DESCRIPTION
Runs the fork server whilst using the generate command. This allows generate sub-command to actually make progress when pushing child commands to the work queue.

Also, added a change to run commands in the resulting build scripts in sub-shells preventing any `cd` commands in rules causing the root directory to change.

Should fix #408.