### PR TITLE
Use `tup` instead of legacy `tup upd` internally, and in docs.

### DIFF
--- a/bootstrap-ldpreload.sh
+++ b/bootstrap-ldpreload.sh
@@ -4,7 +4,7 @@ CFLAGS="-g" TUP_SERVER="ldpreload" ./build.sh
 if [ ! -d .tup ]; then
 	./build/tup init
 fi
-./build/tup upd
+./build/tup
 echo "Build complete. If ./tup works, you can remove the 'build' directory."
 if ! grep "CONFIG_TUP_SERVER=ldpreload" tup.config > /dev/null 2>&1; then
 	echo "Warning: CONFIG_TUP_SERVER=ldpreload not found in tup.config. This script builds the bootstrapped tup with the ldpreload server, but does not automatically configure the full build to use this server. You will need to do this manually by editing tup.config." 1>&2

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,5 +4,5 @@ CFLAGS="-g" ./build.sh
 if [ ! -d .tup ]; then
 	./build/tup init
 fi
-./build/tup upd
+./build/tup
 echo "Build complete. If ./tup works, you can remove the 'build' directory."

--- a/build.sh
+++ b/build.sh
@@ -85,7 +85,7 @@ CFLAGS="$CFLAGS -DHAVE_CONFIG_H"
 for i in ../src/tup/*.c ../src/tup/tup/main.c ../src/tup/monitor/null.c ../src/tup/flock/fcntl.c ../src/inih/ini.c ../src/pcre/*.c $plat_files; do
 	echo "  bootstrap CC $CFLAGS $i"
 	# Put -I. first so we find our new luabuiltin.h file, not one built
-	# by a previous 'tup upd'.
+	# by a previous invocation of 'tup'.
 	$CC $CFLAGS -c $i -I. -I../src -I../src/pcre $plat_cflags
 done
 

--- a/docs/html/ex_dependencies.html
+++ b/docs/html/ex_dependencies.html
@@ -30,7 +30,7 @@ echo "Output from test.sh"
 Output from test.sh
 </pre>
 
-<p>So our simple script ran and created the <span class="filename">output.txt</span> file. When will tup decide to run the script again to create a new output? The answer is simple: whenever the <span class="filename">test.sh</span> script changes! Watch as <span class="cmd">tup upd</span> does not re-run the script until the script is touched:</p>
+<p>So our simple script ran and created the <span class="filename">output.txt</span> file. When will tup decide to run the script again to create a new output? The answer is simple: whenever the <span class="filename">test.sh</span> script changes! Watch as <span class="cmd">tup</span> does not re-run the script until the script is touched:</p>
 
 <pre>
 <span class="prompt">$</span> tup

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -52,10 +52,10 @@ brew install tup
 </ul>
 <p>What this means is:</p>
 <ul>
-  <li>Your edit/compile/test cycle is quick, even if your project is large. You just run: <span class="cmd">tup upd</span></li>
-  <li>You don't have to outsmart your build system by starting it in a subdirectory to make it go faster. Anywhere in the tree: <span class="cmd">tup upd</span></li>
-  <li>Your version control lets you rename a file. Does your build system? <span class="cmd">tup upd</span></li>
-  <li>Fresh checkouts: gone.<br>'clean' builds: gone.<br>Worries: gone.<br>What remains: <span class="cmd">tup upd</span></li>
+  <li>Your edit/compile/test cycle is quick, even if your project is large. You just run: <span class="cmd">tup</span></li>
+  <li>You don't have to outsmart your build system by starting it in a subdirectory to make it go faster. Anywhere in the tree: <span class="cmd">tup</span></li>
+  <li>Your version control lets you rename a file. Does your build system? <span class="cmd">tup</span></li>
+  <li>Fresh checkouts: gone.<br>'clean' builds: gone.<br>Worries: gone.<br>What remains: <span class="cmd">tup</span></li>
 </ul>
 
 <h2>How is it so awesome?</h2>

--- a/docs/html/tips_and_tricks.html
+++ b/docs/html/tips_and_tricks.html
@@ -14,7 +14,7 @@ being compatible with make. It can be put in an .emacs (place the cursor at the 
 
 <p>To try it out type:</p>
 
-<pre class="code">M-x compile [enter] cd /top/level/of/project/with/errors/ ; tup upd [enter]
+<pre class="code">M-x compile [enter] cd /top/level/of/project/with/errors/ ; tup [enter]
 </pre>
 
 <p>And for handling colors in emacs:</p>

--- a/docs/journal.html
+++ b/docs/journal.html
@@ -555,7 +555,7 @@ $(objs): %.o: %.c
    $ ls
    Makefile  foo.c  foo.h  foo.o  ok.c  ok.o  prog
    $ &lt;update Makefile&gt;
-   $ tup upd
+   $ tup
    Compile 'foo.c' into 'foo.o'
    Compile 'ok.c' into 'ok.o'
    Link 'foo.o ok.o' into 'mainexe'

--- a/docs/todo
+++ b/docs/todo
@@ -34,7 +34,7 @@ cache flags and write out the diff before a commit? eg: no need to add a command
 
 replace 'tup monitor' with a tup.sh function and wrap it with valgrind
 
-monitor should move deleted files to use dir=-1 instead of actually doing the full node deletion. The full deletion is done at next tup upd. file should be renamed to avoid unique constraint violation (name=tupid?)
+monitor should move deleted files to use dir=-1 instead of actually doing the full node deletion. The full deletion is done at next tup invocation. file should be renamed to avoid unique constraint violation (name=tupid?)
 
 look at gcov, gperf
 
@@ -170,10 +170,10 @@ html:
   error messages (eg: you get this error message if...)
   document !macro.c !macro.o
   wc3 validate tup webpages
-  should be able to checkout, tup init, tup upd
-   - or checkout the project as a subdirectory: tup init at a higher level, tup upd
+  should be able to checkout, tup init, tup
+   - or checkout the project as a subdirectory: tup init at a higher level, tup
 
 node-variables:
    * trying to store an absolute path in a node var with full_deps on
       - currently works if you add the node var after the full deps have been found
-   
+

--- a/src/tup/graph.c
+++ b/src/tup/graph.c
@@ -407,7 +407,7 @@ static struct node *find_or_create_node(struct graph *g, struct tup_entry *tent)
 }
 
 /* Callback for adding group dependencies to the regular update graph. This
- * just adds a link from <group1> -> <group2> so that if we 'tup upd
+ * just adds a link from <group1> -> <group2> so that if we 'tup
  * <group2>', we also build everything in group1. See t3088, t3089.
  */
 int build_graph_group_cb(void *arg, struct tup_entry *tent)

--- a/src/tup/monitor/inotify.c
+++ b/src/tup/monitor/inotify.c
@@ -23,17 +23,17 @@
  * scanning algorithm:
  *
  *        Step 1.  Start at initial directory foo.  Add watch.
- *        
+ *
  *        Step 2.  Setup handlers for watch created in Step 1.
  *                 Specifically, ensure that a directory created
  *                 in foo will result in a handled CREATE_SUBDIR
  *                 event.
- *        
+ *
  *        Step 3.  Read the contents of foo.
- *        
+ *
  *        Step 4.  For each subdirectory of foo read in step 3, repeat
  *                 step 1.
- *        
+ *
  *        Step 5.  For any CREATE_SUBDIR event on bar, if a watch is
  *                 not yet created on bar, repeat step 1 on bar.
  */
@@ -286,7 +286,7 @@ int monitor(int argc, char **argv)
 
 			/* Need to clear out all saved structures (the dircache
 			 * and tup_entries), then shut the monitor off before
-			 * turning it back on. If there is a waiting 'tup upd'
+			 * turning it back on. If there is a waiting 'tup'
 			 * it will get the lock and update in scan mode before
 			 * we return from tup_lock_init(). Then we should be
 			 * good to go.

--- a/src/tup/updater.c
+++ b/src/tup/updater.c
@@ -466,7 +466,7 @@ int todo(int argc, char **argv)
 	if(rc < 0)
 		return -1;
 	if(rc == 1) {
-		printf("Run 'tup upd' to bring the system up-to-date.\n");
+		printf("Run 'tup' to bring the system up-to-date.\n");
 		goto out_ok;
 	}
 	printf("tup: Everything is up-to-date.\n");


### PR DESCRIPTION
Internally, and in docs, use `tup` rather than `tup upd`.