### PR TITLE
Pass -x to grep commands in tests where entire line should match

### DIFF
--- a/test/t2204-generate-shell-script-mkdir.sh
+++ b/test/t2204-generate-shell-script-mkdir.sh
@@ -37,7 +37,7 @@ generate $generate_script_name
 ./$generate_script_name
 check_exist sub1/out/dir/foo.txt sub1/out/bar.txt sub1/out/dir/baz.txt
 
-if ! grep '^mkdir' $generate_script_name | wc -l | grep 2 > /dev/null; then
+if [ "$(grep -c '^mkdir' $generate_script_name)" != 2 ]; then
 	echo "Error: Generated script should have 2 mkdirs" 1>&2
 	exit 1
 fi

--- a/test/t3051-group-ordering2.sh
+++ b/test/t3051-group-ordering2.sh
@@ -33,13 +33,13 @@ touch bar.c
 update
 
 touch foo.h.in
-if ! tup upd | grep 'gcc -c' | wc -l | grep 1 > /dev/null; then
+if [ "$(tup | grep -c 'gcc -c')" != 1 ]; then
 	echo "Error: Expected only one file to compile" 1>&2
 	exit 1
 fi
 
 touch bar.h.in
-if ! tup upd | grep 'gcc -c' | wc -l | grep 0 > /dev/null; then
+if [ "$(tup | grep -c 'gcc -c')" != 0 ]; then
 	echo "Error: Expected no files to compile" 1>&2
 	exit 1
 fi

--- a/test/t4001-two-c-files.sh
+++ b/test/t4001-two-c-files.sh
@@ -28,9 +28,7 @@ sym_check bar.o bar1
 
 # Verify only foo is compiled if foo.c is touched
 echo "void foo2(void) {}" >> foo.c
-if tup upd | grep 'gcc -c' | wc -l | grep 1 > /dev/null; then
-	:
-else
+if [ "$(tup | grep -c 'gcc -c')" != 1 ]; then
 	echo "Only foo.c should have been compiled." 1>&2
 	exit 1
 fi
@@ -39,9 +37,7 @@ sym_check foo.o main foo2
 # Verify both are compiled if both are touched, but only linked once
 rm foo.o
 touch foo.c bar.c
-if tup upd | grep 'gcc .* -o prog' | wc -l | grep 1 > /dev/null; then
-	:
-else
+if [ "$(tup | grep -c 'gcc .* -o prog')" != 1 ]; then
 	echo "Program should have only been linked once." 1>&2
 	exit 1
 fi

--- a/test/t4062-full-deps.sh
+++ b/test/t4062-full-deps.sh
@@ -51,14 +51,12 @@ esac
 tup_dep_exist $path $filename . 'gcc -c foo.c -o foo.o'
 
 tup fake_mtime $path$filename 5
-if tup upd | grep 'gcc -c' | wc -l | grep 1 > /dev/null; then
-	:
-else
+if [ "$(tup | grep -c 'gcc -c')" != 1 ]; then
 	echo "Changing timestamp on /usr/bin/gcc should have caused foo.c to re-compile." 1>&2
 	exit 1
 fi
 
-if [ "`tup entry $path$filename`" = "" ]; then
+if [ -z "$(tup entry $path$filename)" ]; then
 	echo "Error: tup entry failed on $path$filename" 1>&2
 	exit 1
 fi

--- a/test/t4067-full-deps5.sh
+++ b/test/t4067-full-deps5.sh
@@ -44,14 +44,14 @@ update
 tup_object_no_exist $path $filename
 
 set_full_deps
-if ! tup upd | grep 'gcc -c' | wc -l | grep 2 > /dev/null; then
+if [ "$(tup | grep -c 'gcc -c')" != 2 ]; then
 	echo "Error: All files should have been recompiled when updater.full_deps was set." 1>&2
 	exit 1
 fi
 tup_object_exist $path $filename
 
 clear_full_deps
-if ! tup upd | grep 'gcc -c' | wc -l | grep 0 > /dev/null; then
+if [ "$(tup | grep -c 'gcc -c')" != 0 ]; then
 	echo "Error: No files should have been recompiled when updater.full_deps was cleared." 1>&2
 	exit 1
 fi

--- a/test/t4102-output-different-dir-gitignore2.sh
+++ b/test/t4102-output-different-dir-gitignore2.sh
@@ -36,7 +36,7 @@ update
 gitignore_good baz.txt foo/.gitignore
 gitignore_good bar.txt foo/.gitignore
 
-if ! cat foo/.gitignore | grep '\.gitignore' | wc -l | grep 1 > /dev/null; then
+if [ "$(grep -c '\.gitignore' foo/.gitignore)" != 1 ]; then
 	echo "Error: Expected only one .gitignore line in the .gitignore file." 1>&2
 	exit 1
 fi

--- a/test/t6002-broken-update.sh
+++ b/test/t6002-broken-update.sh
@@ -27,9 +27,7 @@ echo "int main(void) {bork}" > foo.c
 update_fail
 
 echo "int main(void) {}" > foo.c
-if tup upd  | grep 'gcc.*foo.o' | wc -l | grep 2 > /dev/null; then
-	:
-else
+if [ "$(tup | grep -c 'gcc.*foo.o')" != 2 ]; then
 	echo "foo.c should have been compiled and linked again." 1>&2
 	exit 1
 fi

--- a/test/t7048-full-deps.sh
+++ b/test/t7048-full-deps.sh
@@ -47,9 +47,7 @@ esac
 tup_dep_exist $path $filename . 'gcc -c foo.c -o foo.o'
 
 tup fake_mtime $path$filename 5
-if tup upd | grep 'gcc -c' | wc -l | grep 1 > /dev/null; then
-	:
-else
+if [ "$(tup | grep -c 'gcc -c')" != 1 ]; then
 	echo "Changing timestamp on /usr/bin/gcc should have caused foo.c to re-compile." 1>&2
 	exit 1
 fi

--- a/test/t7051-autoupdate7.sh
+++ b/test/t7051-autoupdate7.sh
@@ -39,8 +39,8 @@ HERE
 tup flush
 check_exist foo
 
-if ! cat .tup/.run.txt | wc -l | grep 1 > /dev/null; then
-	echo "Error: tup should update only once" 1>&2
+if [ "$(grep -c executed .tup/.run.txt)" != 1 ]; then
+	echo "Error: ok.sh should have run once" 1>&2
 	exit 1
 fi
 
@@ -49,8 +49,8 @@ cat > Tupfile << HERE
 HERE
 tup flush
 
-if ! cat .tup/.run.txt | wc -l | grep 2 > /dev/null; then
-	echo "Error: tup should update only once" 1>&2
+if [ "$(grep -c executed .tup/.run.txt)" != 2 ]; then
+	echo "Error: ok.sh should have run twice altogether" 1>&2
 	exit 1
 fi
 

--- a/test/t7052-autoupdate8.sh
+++ b/test/t7052-autoupdate8.sh
@@ -38,9 +38,9 @@ HERE
 tup flush
 check_exist prog
 
-if ! cat .tup/.monitor.output | grep Updated | wc -l | grep 1 > /dev/null; then
+if [ "$(grep -c Updated .tup/.monitor.output)" != 1 ]; then
 	sleep 0.5
-	if ! cat .tup/.monitor.output | grep Updated | wc -l | grep 1 > /dev/null; then
+	if [ "$(grep -c Updated .tup/.monitor.output)" != 1 ]; then
 		echo "Monitor output:" 1>&2
 		cat .tup/.monitor.output 1>&2
 		echo "Error: tup should only update once" 1>&2

--- a/test/t8001-keep-going2.sh
+++ b/test/t8001-keep-going2.sh
@@ -37,9 +37,7 @@ HERE
 touch zap.c
 update_fail -k
 
-if tup upd -k 2>&1 | grep gcc | wc -l | grep 1 > /dev/null; then
-	:
-else
+if [ "$(tup -k 2>&1 | grep -c gcc)" != 1 ]; then
 	echo "Error: Only one file should have been compiled." 1>&2
 	exit 1
 fi

--- a/test/t8013-variant-ls.sh
+++ b/test/t8013-variant-ls.sh
@@ -45,7 +45,7 @@ HERE
 touch sub/foo.c sub/bar.c
 update
 
-if ! grep foo.c sub/files.txt | wc -l | grep 1 > /dev/null; then
+if [ "$(grep -c 'foo\.c' sub/files.txt)" != 1 ]; then
 	echo "Error: files.txt should only contain one foo.c" 1>&2
 	cat sub/files.txt
 	exit 1


### PR DESCRIPTION
Several tests check the number of lines returned by a `wc -l` command
by piping the result to grep. In this case, `grep -x` should be used
so that e.g. if the line count is expected to be 2, the line count
can't be 12 or 23 etc. The -x option ensures the full number is matched
rather than searching for it as a substring.