### PR TITLE
Fix buggy readdir-tmpdir tests that used $1 where they should have used $i

### DIFF
--- a/test/t4043-readdir-tmpdir.sh
+++ b/test/t4043-readdir-tmpdir.sh
@@ -44,8 +44,8 @@ cd ..
 update
 
 for i in foo.txt bar.txt tmpsub/baz.txt dir2/a1.txt dir2/a2.txt; do
-	if ! grep "$1" sub/output.dat > /dev/null; then
-		echo "Error: '$1' should be in the output file" 1>&2
+	if ! grep "$i" sub/output.dat > /dev/null; then
+		echo "Error: '$i' should be in the output file" 1>&2
 		exit 1
 	fi
 done

--- a/test/t4044-readdir-tmpdir2.sh
+++ b/test/t4044-readdir-tmpdir2.sh
@@ -44,8 +44,8 @@ cd ..
 update
 
 for i in foo.txt bar.txt; do
-	if ! grep "$1" sub/output.dat > /dev/null; then
-		echo "Error: '$1' should be in the output file" 1>&2
+	if ! grep "$i" sub/output.dat > /dev/null; then
+		echo "Error: '$i' should be in the output file" 1>&2
 		exit 1
 	fi
 done
@@ -70,8 +70,9 @@ HERE
 update
 
 for i in foo.txt bar.txt tmpsub/level2/baz.txt; do
-	if ! grep "$1" sub/output.dat > /dev/null; then
-		echo "Error: '$1' should be in the output file" 1>&2
+	if ! grep "$i" sub/output.dat > /dev/null; then
+		echo "Error: '$i' should be in the output file but isn't:" 1>&2
+		cat sub/output.dat
 		exit 1
 	fi
 done

--- a/test/t4068-readdir-tmpdir3.sh
+++ b/test/t4068-readdir-tmpdir3.sh
@@ -42,8 +42,8 @@ cd ..
 update
 
 for i in level1 level2; do
-	if ! grep "$1" sub/output.dat > /dev/null; then
-		echo "Error: '$1' should be in the output file" 1>&2
+	if ! grep "$i" sub/output.dat > /dev/null; then
+		echo "Error: '$i' should be in the output file" 1>&2
 		exit 1
 	fi
 done
@@ -65,8 +65,9 @@ HERE
 update
 
 for i in sublevel1.1 sublevel1.2; do
-	if ! grep "$1" sub/output.dat > /dev/null; then
-		echo "Error: '$1' should be in the output file" 1>&2
+	if ! grep "$i" sub/output.dat > /dev/null; then
+		echo "Error: '$i' should be in the output file but isn't:" 1>&2
+		cat sub/output.dat 1>&2
 		exit 1
 	fi
 done


### PR DESCRIPTION
Fixes tests that looped over variable $i but accidentally used
`$1` inside the loop instead of `$i`. This causes some tests to fail.
I'm not sure if the failures are due to incorrect tests, or whether
they uncover genuine bugs.