### PR TITLE
Git-ignore /test/tuptesttmp* files

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+/tuptesttmp*


### PR DESCRIPTION
Just to help avoid accidentally committing a failing test directory...