### PR TITLE
Changed error on unspecified output to warning

### DIFF
--- a/src/tup/file.c
+++ b/src/tup/file.c
@@ -730,7 +730,8 @@ static int update_write_info(FILE *f, tupid_t cmdid, struct file_info *info,
 		if(!tent) {
 			struct mapping *map;
 
-			fprintf(f, "tup warning: File '%s' was written to, but is not in .tup/db. You should specify it as an output or ignore it\n", w->filename);
+			if(tup_option_get_flag("display.unspecified_output_warnings"))
+				fprintf(f, "tup warning: File '%s' was written to, but is not in .tup/db. You should specify it as an output or ignore it\n", w->filename);
 
 			TAILQ_FOREACH(map, &info->mapping_list, list) {
 				if(strcmp(map->realname, w->filename) == 0) {

--- a/src/tup/file.c
+++ b/src/tup/file.c
@@ -730,7 +730,7 @@ static int update_write_info(FILE *f, tupid_t cmdid, struct file_info *info,
 		if(!tent) {
 			struct mapping *map;
 
-			fprintf(f, "tup warning: File '%s' was written to, but is not in .tup/db. You probably should specify it as an output\n", w->filename);
+			fprintf(f, "tup warning: File '%s' was written to, but is not in .tup/db. You should specify it as an output or ignore it\n", w->filename);
 
 			TAILQ_FOREACH(map, &info->mapping_list, list) {
 				if(strcmp(map->realname, w->filename) == 0) {

--- a/src/tup/file.c
+++ b/src/tup/file.c
@@ -730,12 +730,7 @@ static int update_write_info(FILE *f, tupid_t cmdid, struct file_info *info,
 		if(!tent) {
 			struct mapping *map;
 
-			fprintf(f, "tup error: File '%s' was written to, but is not in .tup/db. You probably should specify it as an output\n", w->filename);
-			write_bork = 1;
-			if(info->do_unlink) {
-				fprintf(f, " -- Delete: %s\n", w->filename);
-				unlink(w->filename);
-			}
+			fprintf(f, "tup warning: File '%s' was written to, but is not in .tup/db. You probably should specify it as an output\n", w->filename);
 
 			TAILQ_FOREACH(map, &info->mapping_list, list) {
 				if(strcmp(map->realname, w->filename) == 0) {

--- a/src/tup/option.c
+++ b/src/tup/option.c
@@ -90,6 +90,7 @@ static struct option {
 	{"display.job_numbers", "1", NULL, is_flag},
 	{"display.job_time", "1", NULL, is_flag},
 	{"display.quiet", "0", NULL, is_flag},
+	{"display.unspecified_output_warnings", "1", NULL, is_flag},
 	{"monitor.autoupdate", "0", NULL, is_flag},
 	{"monitor.autoparse", "0", NULL, is_flag},
 	{"monitor.foreground", "0", NULL, is_flag},

--- a/tup.1
+++ b/tup.1
@@ -338,6 +338,9 @@ Set to '0' to avoid displaying the runtime of a job along with the results. The 
 .B display.quiet (default '0')
 Set to '1' to prevent tup from displaying most output. Tup will still display a banner and output from any job that writes to stdout/stderr, or any job that returns a non-zero exit code. The progress bar is still displayed; see also display.progress for really quiet output.
 .TP
+.B display.unspecified_output_warnings (default '1')
+Set to '0' to disable warnings, when a file that is not specified as an output is created.
+.TP
 .B monitor.autoupdate (default '0')
 Set to '1' to automatically rebuild if a file change is detected. This only has an effect if the monitor is running. The default is '0', which means you have to type 'tup' when you are ready to update.
 .TP


### PR DESCRIPTION
This changes "tup error: File '%s' was written to, but is not in .tup/db. You probably should specify it as an output" into a warning and adds a configuration option to disable it "display.unspecified_output_warnings".

Why?
- Visual Studio and the mingw-w64 gcc compiler v10.3.0 (MSYS2) produce temporary files with unpredictable names. (see #182)
- The rustc compiler produces output with unpredictable names (see #113)

Fixes #113 and fixes #182