### PR TITLE
Disable more SQLite's features

### DIFF
--- a/src/sqlite3/Tupfile
+++ b/src/sqlite3/Tupfile
@@ -12,6 +12,10 @@ CFLAGS += -DSQLITE_THREADSAFE=0
 # No need to depend on libdl here.
 CFLAGS += -DSQLITE_OMIT_LOAD_EXTENSION
 
+# No need these features.
+CFLAGS += -DSQLITE_OMIT_DESERIALIZE
+CFLAGS += -DSQLITE_OMIT_EXPLAIN
+
 ifneq (@(TUP_USE_SYSTEM_SQLITE),y)
 : foreach *.c |> !cc |>
 endif


### PR DESCRIPTION
`tup` doesn't use them, so let's disable them.