### PR TITLE
Make tup monitor use the correct executable

### DIFF
--- a/src/tup/monitor/inotify.c
+++ b/src/tup/monitor/inotify.c
@@ -900,7 +900,14 @@ static int autoupdate(const char *cmd)
 			}
 		}
 		args[update_argc+3] = NULL;
-		execvp("tup", args);
+		char path[1024];
+		ssize_t len = readlink("/proc/self/exe", path, sizeof(path) - 1);
+		if (len != -1) {
+			path[len] = '\0'; // Null-terminate the string
+		} else {
+			perror("readlink");
+		}
+		execvp(path, args);
 		perror("execvp");
 		exit(1);
 	} else {


### PR DESCRIPTION
In _tup monitor_, tup uses "tup" as path to tup in the rebuild instead of calling the currently executed version. This commit fetches the current executable and uses the same path for the new update process. The 