### PR TITLE
Added `pipe-nt` file ignore to Tup

### DIFF
--- a/src/dllinject/dllinject.c
+++ b/src/dllinject/dllinject.c
@@ -1657,6 +1657,8 @@ static int ignore_file_w(const wchar_t *file)
 		return 1;
 	if (wcscasestr(file, L"SQM\\sqmcpp.log") != NULL)
 		return 1;
+	if (wcsstr(file, L"-pipe-nt-0x") != NULL)
+		return 1;
 	return 0;
 }
 


### PR DESCRIPTION
Linking programs using MinGW on Win32 sometimes causes a `pipe-nt` file to be generated. Tup should ignore this file type as it is a temporary file produced by the linker. 

I can't definitively determine what these files are, as I'm struggling to find anything online. So if anyone has any more info, that would be appreciated! I was compiling using version `13.1.0` of `x86_64-w64-mingw32-gcc`.

I've tried to include as much of the `pipe-nt` file string as possible to avoid a clash with expected file types.

I ran into this when trying to create a fresh build of Tup from the `master` branch:

<img width="1114" height="284" alt="image" src="https://github.com/user-attachments/assets/178e0748-0f99-4a64-b0c0-cd50d0c1bfb1" />
