### PR TITLE
Fix Compiledb containing extra comma

### DIFF
--- a/Tuprules.tup
+++ b/Tuprules.tup
@@ -115,3 +115,8 @@ LDFLAGS_tup-ldpreload.so += $(SHARED)
 LDFLAGS_tup-ldpreload.so += -ldl
 LDFLAGS_tup-ldpreload.so += -pthread
 endif
+
+ifeq (@(LOCK),dotlock)
+CFLAGS += -DUSE_DOTLOCK
+endif
+

--- a/bootstrap-wsl1.sh
+++ b/bootstrap-wsl1.sh
@@ -1,0 +1,19 @@
+#! /bin/sh -e
+# This is similar to bootstrap.sh, except it uses 'tup generate' to build a
+# temporary shell script in case tup needs to be built in an environment that
+# doesn't support FUSE. The resulting tup binary will still require FUSE to
+# operate (on those platforms where it is used).
+
+# Dependencies:
+# libc6-dev
+
+CFLAGS="-g" ./build.sh
+
+if [ ! -d .tup ]; then
+	./build/tup init
+fi
+./build/tup generate --verbose --config local-build-configs/wsl1.config build-wsl1.sh
+./build-wsl1.sh
+echo "Build complete. If ./tup works, you can remove the 'build' directory."
+
+

--- a/local-build-configs/wsl1.config
+++ b/local-build-configs/wsl1.config
@@ -1,0 +1,3 @@
+CONFIG_TUP_SERVER=ldpreload
+CONFIG_LOCK=dotlock
+

--- a/src/ldpreload/ldpreload.c
+++ b/src/ldpreload/ldpreload.c
@@ -724,6 +724,14 @@ static int ignore_file(const char *file)
 		return 1;
 	if(strncmp(file, "/proc/", 6) == 0)
 		return 1;
+	if(strncmp(file, "/var/", 5) == 0)
+		return 1;
+	if(strncmp(file, "/run/", 5) == 0)
+		return 1;
+	if(strncmp(file, "/tmp/", 5) == 0)
+		return 1;
+	if(strncmp(file, "/usr/", 5) == 0)
+		return 1;
 	if(is_ccache_path(file))
 		return 1;
 	return 0;

--- a/src/tup/db.c
+++ b/src/tup/db.c
@@ -255,7 +255,11 @@ static int db_open(void)
 
 	if(tup_db)
 		return 0;
+#ifdef USE_DOTLOCK
+	if(sqlite3_open_v2(TUP_DB_FILE, &tup_db, SQLITE_OPEN_READWRITE, "unix-dotfile") != 0) {
+#else
 	if(sqlite3_open_v2(TUP_DB_FILE, &tup_db, SQLITE_OPEN_READWRITE, NULL) != 0) {
+#endif
 		fprintf(stderr, "Unable to open database: %s\n",
 			sqlite3_errmsg(tup_db));
 		return -1;
@@ -334,7 +338,11 @@ int tup_db_create(int db_sync, int memory_db)
 	} else {
 		dbname = TUP_DB_FILE;
 	}
-	rc = sqlite3_open(dbname, &tup_db);
+#ifdef USE_DOTLOCK
+	rc = sqlite3_open_v2(dbname, &tup_db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, "unix-dotfile");
+#else
+	rc = sqlite3_open_v2(dbname, &tup_db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL);
+#endif
 	if(rc == 0) {
 		printf(".tup repository initialized: %s\n", dbname);
 	} else {

--- a/src/tup/flock/fcntl.c
+++ b/src/tup/flock/fcntl.c
@@ -25,6 +25,89 @@
 #include <unistd.h>
 #include <errno.h>
 
+#define USE_DOTLOCK
+
+#ifdef USE_DOTLOCK
+#include "tup/config.h"
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <string.h>
+#include <dlfcn.h>
+
+#define dotlock_path_len 256
+
+
+static int get_dotlockname(int fd, char *name, size_t len)
+{
+	struct stat file_stat;
+	int ret;
+	ret = fstat (fd, &file_stat);
+	if (ret < 0) return -1;
+
+	int inode = file_stat.st_ino;  // inode now contains inode number of the file with descriptor fd
+
+	// todo: .tup from config.h?
+	//size_t sz = snprintf(name, len, "/run/lock/tup-%d.lock", inode);
+	size_t sz = snprintf(name, len, "/tmp/tup-%d.lock", inode);
+	if (sz >= len) return -1;
+
+	return 0;
+}
+
+
+
+static int make_dotlock(int fd, int wait_type)
+{
+	int prev_errno = errno;
+	int ret = -1;
+	do {
+		char dotlockname[dotlock_path_len];
+		get_dotlockname(fd, dotlockname, dotlock_path_len);
+		//if ((fdl = open(dotlockname, O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) < 0)
+		//int fdl = open(dotlockname, O_WRONLY | O_CREAT | O_EXCL, 0666);
+		int fdl = mkdir(dotlockname, 0666);
+
+		if (fdl < 0)
+		{
+			if (errno == EEXIST) 
+			{
+				ret = 1;
+			}
+			else
+			{
+				ret = -1;
+				break;
+			}
+		}
+		else 
+		{
+			ret = 0;
+			break;
+		}
+		//close(fdl);
+		if (wait_type == 1) sleep(1);
+		else if (wait_type == 2) usleep(10000);
+	} while (wait_type > 0); 
+	errno = prev_errno;
+	return ret;
+}
+
+static int remove_dotlock(int fd)
+{
+	char dotlockname[dotlock_path_len];
+	get_dotlockname(fd, dotlockname, dotlock_path_len);
+	//if (unlink(dotlockname) < 0)
+	if (rmdir(dotlockname) < 0)
+	{
+		return -1;
+	}
+	return 0;
+}
+
+
+
+#endif
+
 int tup_lock_open(int basefd, const char *lockname, tup_lock_t *lock)
 {
 	int fd;
@@ -36,6 +119,7 @@ int tup_lock_open(int basefd, const char *lockname, tup_lock_t *lock)
 		return -1;
 	}
 	*lock = fd;
+	
 	return 0;
 }
 
@@ -48,6 +132,12 @@ void tup_lock_close(tup_lock_t lock)
 
 int tup_flock(tup_lock_t fd)
 {
+#ifdef USE_DOTLOCK
+	//char dotlockname[dotlock_path_len];
+	//get_dotlockname(fd, dotlockname, dotlock_path_len);
+	//while (mkdir(dotlockname, 0666) < 0) {
+	if (make_dotlock(fd, 1) < 0) return -1;
+#else
 	struct flock fl = {
 		.l_type = F_WRLCK,
 		.l_whence = SEEK_SET,
@@ -59,12 +149,20 @@ int tup_flock(tup_lock_t fd)
 		perror("fcntl F_WRLCK");
 		return -1;
 	}
+#endif
 	return 0;
 }
 
 /* Returns: -1 error, 0 got lock, 1 would block */
 int tup_try_flock(tup_lock_t fd)
 {
+#ifdef USE_DOTLOCK
+	//char dotlockname[dotlock_path_len];
+	//get_dotlockname(fd, dotlockname, dotlock_path_len);
+	//if (mkdir(dotlockname, 0666) < 0) {
+	int mdl = make_dotlock(fd, 0);
+	if (mdl != 0) return mdl;
+#else
 	struct flock fl = {
 		.l_type = F_WRLCK,
 		.l_whence = SEEK_SET,
@@ -78,11 +176,21 @@ int tup_try_flock(tup_lock_t fd)
 		perror("fcntl F_WRLCK");
 		return -1;
 	}
+#endif
 	return 0;
 }
 
 int tup_unflock(tup_lock_t fd)
 {
+#ifdef USE_DOTLOCK
+	//char dotlockname[dotlock_path_len];
+	//get_dotlockname(fd, dotlockname, dotlock_path_len);
+	//if (rmdir(dotlockname) < 0) {
+	if (remove_dotlock(fd) < 0) {
+		perror("rm dotlock");
+		return -1;
+	}
+#else
 	struct flock fl = {
 		.l_type = F_UNLCK,
 		.l_whence = SEEK_SET,
@@ -94,11 +202,18 @@ int tup_unflock(tup_lock_t fd)
 		perror("fcntl F_UNLCK");
 		return -1;
 	}
+#endif
 	return 0;
 }
 
 int tup_wait_flock(tup_lock_t fd)
 {
+#ifdef USE_DOTLOCK
+	//char dotlockname[dotlock_path_len];
+	//get_dotlockname(fd, dotlockname, dotlock_path_len);
+	//while (mkdir(dotlockname, 0666) < 0) {
+	if (make_dotlock(fd, 2) < 0) return -1;
+#else
 	struct flock fl;
 
 	while(1) {
@@ -116,5 +231,7 @@ int tup_wait_flock(tup_lock_t fd)
 			break;
 		usleep(10000);
 	}
+#endif
 	return 0;
 }
+

--- a/src/tup/flock/fcntl.c
+++ b/src/tup/flock/fcntl.c
@@ -25,8 +25,6 @@
 #include <unistd.h>
 #include <errno.h>
 
-#define USE_DOTLOCK
-
 #ifdef USE_DOTLOCK
 #include "tup/config.h"
 #include <sys/stat.h>

--- a/src/tup/luaparser.c
+++ b/src/tup/luaparser.c
@@ -815,9 +815,10 @@ int tup_lua_parser_new_state(void)
 
 int parse_lua_include_rules(struct tupfile *tf)
 {
+	int top = lua_gettop(gls);
 	if(parser_include_rules(tf, "Tuprules.lua") < 0) {
 		if(tf->luaerror == TUPLUA_PENDINGERROR) {
-			assert(lua_gettop(gls) == 2);
+			assert(lua_gettop(gls) == top + 2);
 			fprintf(tf->f, "tup error %s\n", tuplua_tostring(gls, -1));
 			lua_pop(gls, 1);
 			tf->luaerror = TUPLUA_ERRORSHOWN;
@@ -830,13 +831,14 @@ int parse_lua_include_rules(struct tupfile *tf)
 int parse_lua_tupfile(struct tupfile *tf, struct buf *b, const char *name)
 {
 	struct tuplua_reader_data lrd = {b, 0};
+	int top = lua_gettop(gls);
 
 	lua_getfield(gls, LUA_REGISTRYINDEX, "tup_traceback");
 
 	if(lua_load(gls, &tuplua_reader, &lrd, name, 0) != LUA_OK) {
 		fprintf(tf->f, "tup error %s\n", tuplua_tostring(gls, -1));
 		tf->luaerror = TUPLUA_PENDINGERROR;
-		assert(lua_gettop(gls) == 2);
+		assert(lua_gettop(gls) == top + 2);
 		return -1;
 	}
 
@@ -849,7 +851,7 @@ int parse_lua_tupfile(struct tupfile *tf, struct buf *b, const char *name)
 			fprintf(tf->f, "tup error %s\n", tuplua_tostring(gls, -1));
 		tf->luaerror = TUPLUA_ERRORSHOWN;
 		lua_pop(gls, 2);
-		assert(lua_gettop(gls) == 0);
+		assert(lua_gettop(gls) == top);
 		return -1;
 	}
 


### PR DESCRIPTION
When using multiple variants, the compiledb files gets an extra comma making it fail to parse as valid json.