### PR TITLE
Fix extra comma in compiledb

### DIFF
--- a/src/tup/db.c
+++ b/src/tup/db.c
@@ -7492,15 +7492,9 @@ static void print_json(FILE *f, const char *str, int len)
 
 static int print_compile_db(FILE *f, struct tup_entry *cmdtent, struct tup_entry *filetent)
 {
-	static int first_time = 1;
 	struct tup_entry *srctent = variant_tent_to_srctent(cmdtent->parent);
 	struct estring e;
 
-	if(first_time) {
-		first_time = 0;
-	} else {
-		fprintf(f, ",\n");
-	}
 	fprintf(f, "{\n");
 	fprintf(f, "    \"directory\": \"");
 	estring_init(&e);
@@ -7554,12 +7548,15 @@ int tup_db_create_compile_db(FILE *f, struct variant *variant)
 		RB_FOREACH(stt, tent_entries, &stickies) {
 			if(stt->tent->type == TUP_NODE_FILE ||
 			   stt->tent->type == TUP_NODE_GENERATED) {
+				if (!empty) {
+					fprintf(f, ",\n");
+				}
 				print_compile_db(f, cmdtent, stt->tent);
+				empty = 0;
 			}
 		}
 		free_tent_tree(&stickies);
 
-		empty = 0;
 	}
 	fprintf(f, "\n]\n");
 	if(tup_db_commit() < 0)


### PR DESCRIPTION
When using multiple variants, the compiledb files are generated with an extra comma, resulting in parsing errors as invalid json.