### PR TITLE
bugfix: cleanup nested auto generated variant directories

### DIFF
--- a/src/tup/db.c
+++ b/src/tup/db.c
@@ -1732,7 +1732,7 @@ static int delete_variant_dir(struct tup_entry *tent, void *arg, int (*callback)
 		if(tup_entry_add(he->tupid, &subtent) < 0)
 			return -1;
 
-		if(he->type == TUP_NODE_DIR) {
+		if(he->type == TUP_NODE_DIR || he->type == TUP_NODE_GENERATED_DIR) {
 			flags = AT_REMOVEDIR;
 			if(delete_variant_dir(subtent, arg, callback) < 0)
 				return -1;


### PR DESCRIPTION
When removing source directories in a project which as auto-generated nested variant output directories, only the top ones are removed from the database, leaving it in a unusable state where tup just returns an error like: "tup error: Unable to find parent entry [258733] for node 315876".

This pr fixes this.