### PR TITLE
Simplify macOS CI: use stock FUSE-T instead of building libfuse

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -22,43 +22,38 @@ jobs:
         # API-compatible with macFUSE, no kernel extension needed.
         # https://github.com/macos-fuse-t/fuse-t
         brew tap macos-fuse-t/homebrew-cask
-        brew install fuse-t
-        brew install pkg-config pcre2 ccache cmake
+        # Use fully qualified tap path to ensure brew reads the local tap
+        # (not a stale Homebrew JSON API cache). We need >= 1.0.54 which
+        # includes the recv-EOF unmount fix (macos-fuse-t/libfuse#11).
+        brew install --cask macos-fuse-t/cask/fuse-t
+        brew install pkg-config pcre2 ccache
         pip3 install --break-system-packages sh
-    - name: Create macFUSE-compatible header symlinks
+    - name: Create macFUSE-compatible symlinks
       run: |
-        # FUSE-T puts headers in a framework; tup expects /usr/local/include/fuse/
+        # FUSE-T installs headers in a framework and pkg-config as fuse-t.pc,
+        # but tup's build expects /usr/local/include/fuse/ and fuse.pc.
         sudo mkdir -p /usr/local/include/fuse
         sudo ln -sf /Library/Frameworks/fuse_t.framework/Headers/* /usr/local/include/fuse/
-    - name: Build patched libfuse for FUSE-T
-      run: |
-        # FUSE-T's libfuse has an unmount teardown bug that causes non-zero
-        # exit after every successful FUSE operation. We build from a patched
-        # fork until the fix is merged upstream.
-        # Fix: https://github.com/macos-fuse-t/libfuse/pull/11
-        git clone https://github.com/petemoore/libfuse.git /tmp/libfuse-src \
-          --branch fix/recv-eof-and-attrcache --depth 1
-        cd /tmp/libfuse-src && mkdir build && cd build
-        cmake .. && make -j$(sysctl -n hw.ncpu)
 
-        # Install patched library over FUSE-T's version
-        install_name_tool -id /usr/local/lib/libfuse-t.dylib lib/libfuse-t.dylib
-        sudo cp lib/libfuse-t.dylib /usr/local/lib/libfuse-t.dylib
-        sudo cp lib/libfuse-t.a /usr/local/lib/libfuse-t.a
+        # FUSE-T's dylib uses @rpath as its install name, but tup's build
+        # doesn't set an rpath. Fix the dylib's install name to its absolute
+        # path so the linker embeds that directly.
+        sudo install_name_tool -id /usr/local/lib/libfuse-t.dylib /usr/local/lib/libfuse-t.dylib
 
-        # Create fuse.pc (FUSE-T doesn't ship one)
-        sudo mkdir -p /usr/local/lib/pkgconfig
-        sudo tee /usr/local/lib/pkgconfig/fuse.pc > /dev/null << 'EOF'
+        # Create fuse.pc that wraps fuse-t.pc and adds the -D_FILE_OFFSET_BITS=64
+        # flag required by the FUSE headers.
+        sudo tee /usr/local/lib/pkgconfig/fuse.pc > /dev/null << 'PKGCONFIG'
         prefix=/usr/local
         exec_prefix=${prefix}
         libdir=${exec_prefix}/lib
         includedir=${prefix}/include
         Name: fuse
-        Description: FUSE-T libfuse
+        Description: FUSE-T (macFUSE-compatible)
         Version: 2.9.9
+        Requires.private: fuse-t
         Libs: -L${libdir} -lfuse-t -pthread
         Cflags: -I${includedir}/fuse -D_FILE_OFFSET_BITS=64
-        EOF
+        PKGCONFIG
     - name: Build (bootstrap)
       run: ./bootstrap.sh
     - name: Run tests

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -32,35 +32,34 @@ sudo apt-get install tup
 <h4>macOS</h4>
 <p>Tup requires a FUSE implementation on macOS. <a href="https://github.com/macos-fuse-t/fuse-t">FUSE-T</a> is recommended &mdash; it runs entirely in user space (no kernel extension needed) and is API-compatible with macFUSE.</p>
 
-<p>Install FUSE-T and build dependencies:</p>
+<p>Install FUSE-T (version 1.0.54 or later) and build dependencies:</p>
 <pre>
 brew tap macos-fuse-t/homebrew-cask
 brew install fuse-t
-brew install pkg-config pcre2 cmake
+brew install pkg-config pcre2
 </pre>
 
-<p>Build the patched libfuse (fixes an <a href="https://github.com/macos-fuse-t/libfuse/pull/11">unmount teardown issue</a> in FUSE-T):</p>
+<p>Create macFUSE-compatible symlinks and fix the dylib install name:</p>
 <pre>
-git clone https://github.com/petemoore/libfuse.git --branch fix/recv-eof-on-unmount --depth 1
-cd libfuse &amp;&amp; mkdir build &amp;&amp; cd build &amp;&amp; cmake .. &amp;&amp; make
-install_name_tool -id /usr/local/lib/libfuse-t.dylib lib/libfuse-t.dylib
-sudo cp lib/libfuse-t.dylib /usr/local/lib/libfuse-t.dylib
-sudo cp lib/libfuse-t.a /usr/local/lib/libfuse-t.a
 sudo mkdir -p /usr/local/include/fuse
 sudo ln -sf /Library/Frameworks/fuse_t.framework/Headers/* /usr/local/include/fuse/
-sudo mkdir -p /usr/local/lib/pkgconfig
+sudo install_name_tool -id /usr/local/lib/libfuse-t.dylib /usr/local/lib/libfuse-t.dylib
+</pre>
+
+<p>Create a <code>fuse.pc</code> pkg-config file (FUSE-T ships <code>fuse-t.pc</code> but tup expects <code>fuse.pc</code>):</p>
+<pre>
 sudo tee /usr/local/lib/pkgconfig/fuse.pc &gt; /dev/null &lt;&lt; 'EOF'
 prefix=/usr/local
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 Name: fuse
-Description: FUSE-T libfuse
+Description: FUSE-T (macFUSE-compatible)
 Version: 2.9.9
+Requires.private: fuse-t
 Libs: -L${libdir} -lfuse-t -pthread
 Cflags: -I${includedir}/fuse -D_FILE_OFFSET_BITS=64
 EOF
-cd ../..
 </pre>
 
 <p>Build tup:</p>
@@ -70,7 +69,7 @@ cd tup
 ./bootstrap.sh
 </pre>
 
-<p>Alternatively, if you already have <a href="https://macfuse.github.io/">macFUSE</a> installed (requires enabling the kernel extension in System Settings &gt; Privacy &amp; Security), tup will use it automatically without the patched libfuse steps above.</p>
+<p>Alternatively, if you already have <a href="https://macfuse.github.io/">macFUSE</a> installed (requires enabling the kernel extension in System Settings &gt; Privacy &amp; Security), tup will use it automatically without the steps above.</p>
 <p>If you use <a href="http://www.macports.org/">MacPorts</a>:</p>
 <pre>sudo port install tup</pre>
 


### PR DESCRIPTION
## Summary

The unmount teardown fix ([macos-fuse-t/libfuse#11](https://github.com/macos-fuse-t/libfuse/pull/11)) has landed upstream and shipped in FUSE-T 1.0.54. This removes the custom libfuse build-from-source step and uses the stock FUSE-T installation directly.

- Remove git clone / cmake build of patched libfuse fork
- Remove `cmake` from brew install (no longer needed)
- Use fully qualified tap path to avoid stale Homebrew JSON API cache
- Fix libfuse-t.dylib install name (`@rpath` -> absolute path)
- Create `fuse.pc` with `-D_FILE_OFFSET_BITS=64` (FUSE-T's `fuse-t.pc` doesn't include this flag, but the FUSE headers require it)
- Simplify macOS install docs to match

Supersedes #528 (whose changes were already applied to master).

## Test plan

- [x] CI passes on [petemoore/tup#2](https://github.com/petemoore/tup/pull/2) (ubuntu + macos jobs)
- [x] Verified FUSE-T 1.0.54 is installed (not a stale cached version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)