### PR TITLE
fix negative percentage and corrupt pgrogress par on large builds

### DIFF
--- a/src/tup/progress.c
+++ b/src/tup/progress.c
@@ -34,8 +34,8 @@ static int cur_phase = -1;
 static int sum;
 static int sum_width;
 static int total;
-static int job_time;
-static int total_time;
+static time_t job_time;
+static time_t total_time;
 static int max_jobs;
 static int is_active = 0;
 static int color_len;
@@ -47,7 +47,7 @@ static int display_job_time;
 static struct timespan gts;
 static struct timespan main_ts;
 
-static int get_time_remaining(char *dest, int len, int part, int whole, int approx);
+static int get_time_remaining(char *dest, int len, time_t part, time_t whole, int approx);
 
 /* Each of these corresponds to one unit of info that can be displayed inside
  * the progress bar (eg: ETA, Remaining, Active). Maxlen remains constant for
@@ -134,7 +134,7 @@ void tup_main_progress(const char *s)
 	tup_show_message(s);
 }
 
-void start_progress(int new_total, int new_total_time, int new_max_jobs)
+void start_progress(int new_total, time_t new_total_time, int new_max_jobs)
 {
 	int i;
 	char buf[256];
@@ -170,24 +170,31 @@ void start_progress(int new_total, int new_total_time, int new_max_jobs)
 void skip_result(struct tup_entry *tent)
 {
 	sum++;
-	if(tent) {
+	if(tent && total_time != -1 && tent->mtime.tv_sec != -1) {
 		total_time -= tent->mtime.tv_sec;
 	}
 }
 
 static int percent_complete(void)
 {
+	int percent;
+
 	if(!total)
 		return 0;
 	/* Use the job times if we have them available since it will report
 	 * a more accurate percentage complete than just the job count.
 	 */
 	if(total_time > 0) {
-		return (job_time*100)/total_time;
+		percent = (int)(((double)job_time * 100.0) / (double)total_time);
+	} else {
+		/* Default to job count if we can't use previous execution times. */
+		percent = (int)(((double)sum * 100.0) / (double)total);
 	}
-
-	/* Default to job count if we can't use previous execution times. */
-	return (sum*100)/total;
+	if(percent < 0)
+		return 0;
+	if(percent > 100)
+		return 100;
+	return percent;
 }
 
 void show_result(struct tup_entry *tent, int is_error, struct timespan *ts, const char *extra_text, int always_display)
@@ -195,7 +202,8 @@ void show_result(struct tup_entry *tent, int is_error, struct timespan *ts, cons
 	FILE *f;
 	float tdiff = 0.0;
 
-	job_time += tent->mtime.tv_sec;
+	if(tent->mtime.tv_sec != -1)
+		job_time += tent->mtime.tv_sec;
 
 	if(ts) {
 		tdiff = timespan_seconds(ts);
@@ -253,7 +261,7 @@ void show_result(struct tup_entry *tent, int is_error, struct timespan *ts, cons
 	color_error_mode_clear();
 }
 
-static int get_time_remaining(char *dest, int len, int part, int whole, int approx)
+static int get_time_remaining(char *dest, int len, time_t part, time_t whole, int approx)
 {
 	const char *eq = "=";
 
@@ -267,8 +275,8 @@ static int get_time_remaining(char *dest, int len, int part, int whole, int appr
 		timespan_end(&gts);
 		ms = timespan_milliseconds(&gts);
 
-		/* This can easily overflow, so do the computation in float */
-		total_runtime = (time_t)((float)ms * (float)whole / (float)part);
+		/* This can easily overflow, so do the computation in double. */
+		total_runtime = (time_t)((double)ms * (double)whole / (double)part);
 		time_left = total_runtime - ms;
 
 		/* Try to find the best units. Note that we use +1 because the
@@ -322,6 +330,10 @@ void show_progress(int active, enum TUP_NODE_TYPE type)
 		} else {
 			fill = max * percent_complete() / 100;
 		}
+		if(fill < 0)
+			fill = 0;
+		if(fill > max)
+			fill = max;
 
 		if(color_len) {
 			memset(buf, ' ', sizeof(buf));

--- a/src/tup/progress.h
+++ b/src/tup/progress.h
@@ -23,6 +23,7 @@
 
 #include "db_types.h"
 #include <stdio.h>
+#include <time.h>
 
 struct tup_entry;
 struct timespan;
@@ -30,7 +31,7 @@ struct timespan;
 void progress_init(void);
 void tup_show_message(const char *s);
 void tup_main_progress(const char *s);
-void start_progress(int new_total, int new_total_time, int new_max_jobs);
+void start_progress(int new_total, time_t new_total_time, int new_max_jobs);
 void skip_result(struct tup_entry *tent);
 void show_result(struct tup_entry *tent, int is_error, struct timespan *ts, const char *extra_text, int always_display);
 void show_progress(int active, enum TUP_NODE_TYPE type);

--- a/test/t5122-progress-overflow.sh
+++ b/test/t5122-progress-overflow.sh
@@ -1,0 +1,64 @@
+#! /bin/sh -e
+# tup - A file-based build system
+#
+# Copyright (C) 2026  Mike Shal <marfey@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Make sure large stored job times cannot overflow the progress percentage and
+# make the progress bar exceed display.width.
+. ./tup.sh
+check_no_windows sqlite3 executable
+
+cat > .tup/options << HERE
+[display]
+color = never
+progress = 1
+width = 20
+
+[updater]
+num_jobs = 1
+HERE
+
+cat > Tupfile << HERE
+: |> touch %o |> out1
+: |> touch %o |> out2
+: |> touch %o |> out3
+HERE
+update
+
+rm -f out1 out2 out3
+sqlite3 .tup/db << HERE
+update node set mtime = 30000000 where name in ('touch out1', 'touch out2', 'touch out3');
+HERE
+
+tup upd > .tup/progress-output
+tr '\r' '\n' < .tup/progress-output | grep '^ \[' > .tup/progress-lines
+
+if [ ! -s .tup/progress-lines ]; then
+	echo "*** Expected progress output" 1>&2
+	cat .tup/progress-output 1>&2
+	exit 1
+fi
+
+while IFS= read -r line; do
+	len=`printf "%s" "$line" | wc -c | sed 's/ //g'`
+	if [ $len -gt 20 ]; then
+		echo "*** Progress line exceeded display.width: $len" 1>&2
+		printf "%s\n" "$line" 1>&2
+		exit 1
+	fi
+done < .tup/progress-lines
+
+eotup

--- a/test/t5123-progress-overflow-color.sh
+++ b/test/t5123-progress-overflow-color.sh
@@ -17,13 +17,13 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 # Make sure large stored job times cannot overflow the progress percentage and
-# make the progress bar exceed display.width.
+# make the colored progress bar exceed display.width.
 . ./tup.sh
 check_no_windows sqlite3 executable
 
 cat > .tup/options << HERE
 [display]
-color = never
+color = always
 progress = 1
 width = 20
 
@@ -54,7 +54,8 @@ update node set mtime = 1 where name in ('touch out2', 'touch out3', 'touch out4
 HERE
 
 tup upd > .tup/progress-output 2>&1
-tr '\r' '\n' < .tup/progress-output | grep '^ \[' > .tup/progress-lines
+esc=`printf '\033'`
+tr '\r' '\n' < .tup/progress-output | sed "s/${esc}\[[0-9;]*m//g" | grep -a '^ \[' > .tup/progress-lines
 
 if [ ! -s .tup/progress-lines ]; then
 	echo "*** Expected progress output" 1>&2
@@ -64,7 +65,7 @@ fi
 
 while IFS= read -r line; do
 	len=`printf "%s" "$line" | wc -c | sed 's/ //g'`
-	if printf "%s\n" "$line" | grep -- '-[0-9][0-9]*%' > /dev/null; then
+	if printf "%s\n" "$line" | grep -a -- '-[0-9][0-9]*%' > /dev/null; then
 		echo "*** Progress percent went negative" 1>&2
 		printf "%s\n" "$line" 1>&2
 		exit 1


### PR DESCRIPTION
Progress bar overflow fix

Problem:
Large builds could make the progress percentage negative and corrupt the
progress bar output. The progress code calculated percentages with int
arithmetic, for example sum * 100 / total. Once the completed job count was
large enough, sum * 100 could overflow a signed int before the division. The
overflowed negative percentage was then used to calculate the filled portion of
the progress bar. That could produce a negative fill width and an invalid buffer
offset in the printf call that renders the bar, causing garbled characters.

Fix:
The percentage calculation now uses wider arithmetic for count-based progress
and stores time-based progress totals in time_t, matching the graph's total
mtime type. The computed percentage is clamped to the display range 0..100.
The rendered progress bar fill length is also clamped to 0..max before it is
used as a printf precision or buffer offset.

Result:
The progress percentage no longer wraps negative on large projects, and the
progress bar cannot render with negative widths or out-of-range buffer offsets
even if the completed count temporarily exceeds the expected total.
