### PR TITLE
Hold child_waiter_root.lock during fork() in master_fork_loop()

### DIFF
--- a/src/tup/server/master_fork.c
+++ b/src/tup/server/master_fork.c
@@ -677,6 +677,7 @@ static int master_fork_loop(void)
 		}
 #endif
 
+		pthread_mutex_lock(&child_waiter_root.lock);
 		pid = fork();
 		if(pid < 0) {
 			perror("fork");
@@ -735,10 +736,11 @@ static int master_fork_loop(void)
 		waiter->pid = pid;
 		waiter->sid = em.sid;
 		waiter->tnode.id = pid;
-		if(thread_tree_insert(&child_waiter_root, &waiter->tnode) < 0) {
+		if(thread_tree_insert_locked(&child_waiter_root, &waiter->tnode) < 0) {
 			fprintf(stderr, "tup internal error: unable to insert pid %i into the thread tree.\n", pid);
 			exit(1);
 		}
+		pthread_mutex_unlock(&child_waiter_root.lock);
 	}
 
 	{

--- a/src/tup/thread_tree.c
+++ b/src/tup/thread_tree.c
@@ -44,10 +44,17 @@ int thread_tree_insert(struct thread_root *troot, struct thread_tree *data)
 {
 	int rc = 0;
 	pthread_mutex_lock(&troot->lock);
+	rc = thread_tree_insert_locked(troot, data);
+	pthread_mutex_unlock(&troot->lock);
+	return rc;
+}
+
+int thread_tree_insert_locked(struct thread_root *troot, struct thread_tree *data)
+{
+	int rc = 0;
 	if(RB_INSERT(thread_entries, &troot->root, data) != NULL)
 		rc = -1;
 	pthread_cond_signal(&troot->cond);
-	pthread_mutex_unlock(&troot->lock);
 	return rc;
 }
 

--- a/src/tup/thread_tree.h
+++ b/src/tup/thread_tree.h
@@ -45,6 +45,7 @@ struct thread_root {
 
 struct thread_tree *thread_tree_search(struct thread_root *troot, int id);
 int thread_tree_insert(struct thread_root *troot, struct thread_tree *data);
+int thread_tree_insert_locked(struct thread_root *troot, struct thread_tree *data);
 void thread_tree_rm(struct thread_root *troot, struct thread_tree *data);
 
 #endif


### PR DESCRIPTION
There is a race on insertion and searching of the thread tree. In master_fork_loop(), fork() is called and then the PID is added to the thread tree by calling thread_tree_insert(). In child_waiter(), wait() is called and then the returned PID is used to call thread_tree_search(). The ordering in master_fork_loop() cannot be changed because the PID is not known until fork() is called but once fork() is called, the child could terminate at any time including before we reach thread_tree_insert().

Consider the following sequence:

child_waiter(): Thread is spawned, waits on condition variable master_fork_loop(): Spawn Job A, add Job A to the thread tree, signal child_waiter()
child_waiter(): Exits wait on condition variable, blocks on wait() master_fork_loop(): Spawn Job B. Thread is interrupted after fork(), before adding to the thread tree
Job B: Exits (status is irrelevant - pass or fail) child_waiter(): wait() unblocks and returns the PID of Job B, which has not been added to the thread tree yet

This is resolved by holding the thread tree lock from before fork() until after adding the new PID to the thread tree at the cost of a minor serialization overhead. A new variant of thread_tree_insert() is added that does not take the lock - thread_tree_insert_locked(). The existing method now calls the locked variant after taking the lock to avoid code duplication.